### PR TITLE
Removed unnecessary quote escaping in issue.getIssueTitle()

### DIFF
--- a/dreditor.user.js
+++ b/dreditor.user.js
@@ -1868,8 +1868,7 @@ Drupal.dreditor.issue.getNewCommentNumber = function() {
  * Gets the issue title.
  */
 Drupal.dreditor.issue.getIssueTitle = function() {
-  // Replace double quotes with single quotes for cvs command line.
-  var title = $('#edit-title').val().replace('"', "'", 'g');
+  var title = $('#edit-title').val();
 
   // Try to fix function names without parenthesis.
   title = title.replace(/([a-z_]+_[a-z_]+)\b(?!\(\))/g, '$&()');


### PR DESCRIPTION
This can be demonstrated with https://drupal.org/node/2075499. We should not escape any characters until we know what _should_ be escaped, like when using it in a commit message.

The example provided has an issue title of:
`Is it possible to put a multiple-select exposed filter on a single date field with "Year" granularity?`

The commit message created is:
`git commit -m "Issue #2075499 by Offlein: Is it possible to put a multiple-select exposed filter on a single date field with 'Year" granularity?."`

Note the current code doesn't even correctly convert both double quotes, and the last PR fixes escaping the double quotes.
