### PR TITLE
Fixed loss of important patch/diff aspects and too aggressive diff coloring.

### DIFF
--- a/src/less/dreditor.less
+++ b/src/less/dreditor.less
@@ -196,6 +196,10 @@
   background-color: #fffbfb;
   color: #c00;
 }
+#dreditor #code tr.old.comment {
+  //background-color: #fbf3f3;
+  color: #c33;
+}
 #dreditor #code tr.old a {
   color: #c00;
 }
@@ -205,13 +209,15 @@
 }
 #dreditor #code tr.new {
   background-color: #fbfffb;
-  color: #008503;
+  //color: #070;
+  color: #00a;
   float: none;
   font-size: 100%;
   font-weight: normal;
 }
-#dreditor #code tr.new .pre {
-  color: #00a;
+#dreditor #code tr.new.comment {
+  //background-color: #f3fbf3;
+  color: #070;
 }
 #dreditor #code tr.new a {
   color: #0a0;
@@ -219,9 +225,6 @@
 #dreditor #code tr.new .ln {
   background-color: #ceffce;
   border-color: #b4e2b4;
-}
-#dreditor #code tr.new.comment .pre {
-  color: #070;
 }
 tr.selected td {
   background: transparent;

--- a/src/less/dreditor.less
+++ b/src/less/dreditor.less
@@ -132,6 +132,7 @@
 #dreditor #code .ln {
   width: 1px;
   border-right: 1px solid #e5e5e5;
+  color: #888;
   text-align: right;
 }
 #dreditor #code .ln:before {
@@ -140,7 +141,7 @@
 #dreditor #code tr {
   background-color: transparent;
   border: 0;
-  color: #888;
+  color: #666;
   margin: 0;
   padding: 0;
 }
@@ -181,8 +182,8 @@
   display: none;
 }
 #dreditor #code tr.file {
-  background-color: #E8F1F6;
-  color: #064A6F;
+  background-color: #f9f9fc;
+  color: #666;
 }
 #dreditor #code tr.file a {
   color: #064A6F;
@@ -192,7 +193,7 @@
   border-color: #BFD4EE;
 }
 #dreditor #code tr.old {
-  background-color: #fdd;
+  background-color: #fffbfb;
   color: #c00;
 }
 #dreditor #code tr.old a {
@@ -203,20 +204,23 @@
   border-color: #e9aeae;
 }
 #dreditor #code tr.new {
-  background-color: #dfd;
+  background-color: #fbfffb;
   color: #008503;
   float: none;
   font-size: 100%;
   font-weight: normal;
 }
+#dreditor #code tr.new .pre {
+  color: #00a;
+}
 #dreditor #code tr.new a {
-  color: #008503;
+  color: #0a0;
 }
 #dreditor #code tr.new .ln {
   background-color: #ceffce;
   border-color: #b4e2b4;
 }
-#dreditor #code .comment {
+#dreditor #code tr.new.comment .pre {
   color: #070;
 }
 tr.selected td {


### PR DESCRIPTION
I like the "new" diff output a lot.  However, I think we've gone a little bit too crazy with the colors — primarily the very aggressive background colors, but also the old/new font colors.

At the same time, diff context lines were changed to appear in almost invisible light gray — even though the context is of utmost importance in patch reviews.

Lastly, Dreditor already does its best to discover code comments, and it colorized them previously — doing so gives a lot more visual structure to the presented lines of code, and on top, it _encourages_ developers to (1) write comments and (2) write _good_ comments.  Especially if you're reviewing tons of patches per day/week, this visualization is key for productivity.

Changes in this PR:
- Contextual diff lines (preceding/following lines of changed lines) are crucial, must not visually appear as unimportant, greyed-out content.
- Restore colorization of comments in added lines for readability and to encourage code comments.
- Generally decrease background color saturation to shift focus on code, instead of colors.

Screenie:

![dreditor-diff-coloring](https://f.cloud.github.com/assets/41992/1475861/1ccf2d60-4642-11e3-874b-c8f1b5f0ba14.png)
