### PR TITLE
Commit message uses wrong escaping slash

### DIFF
--- a/dreditor.user.js
+++ b/dreditor.user.js
@@ -2883,7 +2883,8 @@ div.dreditor-issuecount { line-height: 200%; } \
 ";
 
 // Invoke Dreditor update check once.
-Drupal.dreditor.updateCheck();
+// @todo Is the update check still necessary?
+//Drupal.dreditor.updateCheck();
 
 // End of Content Scope Runner.
 }


### PR DESCRIPTION
See https://drupal.org/node/1653234. The autogenerated commit message command is: `git commit -m "Issue #1653234 by sirjay, mrP: No /"Add menu block/" link."`

Copy-pasting this command is invalid because escaping the quotes should use a \ character and not /.
