### PR TITLE
Feature/more documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,23 +2,22 @@
 
 ## Important notes
 
-As of version > 1.2.3 (Nov 30 2013) we introduced a new source tree layout and developer workflow by using the grunt toolset. This meant splitting up the dreditor.js file into several parts to make better use of extentions and plugins. This allows us to add unit tests later on.
+As of versions after 1.2.3 (Nov 30 2013) we introduced a new source tree layout and developer workflow by using the grunt toolset. This meant splitting up the dreditor.js file into several parts to make better use of extentions and plugins. This allows us to add unit tests later on.
 
 ## Directory structure
 
 The following directories are important for patch writing:
 
-src/js : dreditor code split into smaller parts like extensions and plugins
-src/less : dreditor styling files.
-package.json : contains version number apart from others
-tests/ : contains unit tests
-build/ : contains generated items by running ```grunt```. See Developer workflow below.
+- src/js : dreditor code split into smaller parts like extensions and plugins
+- src/less : dreditor styling files.
+- package.json : contains version number apart from others
+- tests/ : contains unit tests
+- build/ : contains generated items by running ```grunt```. See Developer workflow below.
 
 The following directories are important for distributing Dreditor:
 
-templates/ : used for generating the browser extensions
-release/ : contains the generated packages Dreditor browser extensions.
-build/ : see above
+- templates/ : used for generating the browser extensions
+- release/ : contains the generated packages Dreditor browser extensions.
 
 Both build/ and release/ are added to ```.gitignore``` so make sure these are not added to any PR.
 
@@ -50,23 +49,25 @@ More information coming soon.
 
 [grunt and qunit](http://jordankasper.com/blog/2013/04/automated-javascript-tests-using-grunt-phantomjs-and-qunit/)
 
-# Configure your browser
+## Configure your browser
 
-## Chrome
+### Chrome
 
 1. Navigate to ```chrome://extensions/```
 1. Click on ```Load unpacked extention...```
 1. Browser to the ```build/chrome``` directory and click ```Select```
 
-## Firefox
+### Firefox
 
 (to be defined)
 
-## Safari
+### Safari
 
 (to be defined)
 
-# Grunt
+## Grunt
+
+Grunt helps to continuesly test our code and build the browser packages.
 
 First, ensure that you have the latest [Node.js](http://nodejs.org/) and [npm](http://npmjs.org/) installed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,73 @@
 # Contributing
 
-We changed development workflow by using the grunt toolset. This meant splitting up the dreditor.js file into several parts to make better use of extentions and plugins. This allows us to add unit tests later on.
-
 ## Important notes
 
-1. You'll find source code in the `src` directory.
-1. When `grunt`-ing this project, it will generate an additional `build` and possibly a `release` directory. These have both been added to `.gitignore` and should never be included with any pull requests.
-1. To continuously build a packaged version Dreditor, you can run `grunt watch` in root of the project. It will automatically detect changes made to any file and compile the source code for you.
+As of version > 1.2.3 (Nov 30 2013) we introduced a new source tree layout and developer workflow by using the grunt toolset. This meant splitting up the dreditor.js file into several parts to make better use of extentions and plugins. This allows us to add unit tests later on.
+
+## Directory structure
+
+The following directories are important for patch writing:
+
+src/js : dreditor code split into smaller parts like extensions and plugins
+src/less : dreditor styling files.
+package.json : contains version number apart from others
+tests/ : contains unit tests
+build/ : contains generated items by running ```grunt```. See Developer workflow below.
+
+The following directories are important for distributing Dreditor:
+
+templates/ : used for generating the browser extensions
+release/ : contains the generated packages Dreditor browser extensions.
+build/ : see above
+
+Both build/ and release/ are added to ```.gitignore``` so make sure these are not added to any PR.
+
+## Developer workflow
+
+### Modifying the code
+
+1. Make sure you have Grunt configured correctly as described below.
+1. Run ```grunt watch``` to continues rebuild your changes into the build directory or just ```grunt``` when ready
+1. Configure your browser to use the correct build as described below.
+1. Start coding by
+  1. Create a (new) feature branch. Please don't work in the `1.x` branch directly.
+  1. Fix the code
+  1. Write a test for the new code
+  1. Check the watched output for failing tasks like jslint or tests.
+1. Run `grunt` to ensure code compiles properly. Assuming that you don't see any red, you're ready to go.
+1. Update the documentation to reflect any changes.
+1. Push to your fork's new branch and submit a pull request.
 
 ### Code style
+
 Regarding code style like indentation and whitespace, **follow the conventions you see used in the source already.**
 
-## Modifying the code
+### Writing tests
+
+The ```tests/``` directory contains *.html files with are configured to belong to the test and qunit tasks.
+
+More information coming soon.
+
+[grunt and qunit](http://jordankasper.com/blog/2013/04/automated-javascript-tests-using-grunt-phantomjs-and-qunit/)
+
+# Configure your browser
+
+## Chrome
+
+1. Navigate to ```chrome://extensions/```
+1. Click on ```Load unpacked extention...```
+1. Browser to the ```build/chrome``` directory and click ```Select```
+
+## Firefox
+
+(to be defined)
+
+## Safari
+
+(to be defined)
+
+# Grunt
+
 First, ensure that you have the latest [Node.js](http://nodejs.org/) and [npm](http://npmjs.org/) installed.
 
 Test that Grunt's CLI is installed by running `grunt --version`.  If the command isn't found, run `npm install -g grunt-cli`.  For more information about installing Grunt, see the [getting started guide](http://gruntjs.com/getting-started).
@@ -19,19 +75,3 @@ Test that Grunt's CLI is installed by running `grunt --version`.  If the command
 1. Fork and clone the repo.
 1. Run `npm install` to install all dependencies (including Grunt).
 1. Run `grunt` to grunt this project.
-
-Assuming that you don't see any red, you're ready to go. Just be sure to run `grunt` after making any changes, to ensure that nothing is broken. You can also run `grunt watch` to watch to automatically detect when changes to files have been made.
-
-## Submitting pull requests
-
-1. Create a new branch, please don't work in the `1.x` branch directly.
-2. Fix existing or add new code.
-3. Run `grunt` to ensure code compiles properly.
-4. Update the documentation to reflect any changes.
-5. Push to your fork's new branch and submit a pull request.
-
-## Writing tests
-
-More information coming soon.
-
-[grunt and qunit](http://jordankasper.com/blog/2013/04/automated-javascript-tests-using-grunt-phantomjs-and-qunit/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,29 +8,29 @@ As of versions after 1.2.3 (Nov 30 2013) we introduced a new source tree layout 
 
 The following directories are important for patch writing:
 
-- src/js : dreditor code split into smaller parts like extensions and plugins
-- src/less : dreditor styling files.
-- package.json : contains version number apart from others
-- tests/ : contains unit tests
-- build/ : contains generated items by running ```grunt```. See Developer workflow below.
+- `src/js` : dreditor code split into smaller parts like extensions and plugins
+- `src/less` : dreditor styling files.
+- `package.json` : contains version number apart from others
+- `tests/` : contains unit tests
+- `build/` : contains generated items by running `grunt`. See Developer workflow below.
 
 The following directories are important for distributing Dreditor:
 
-- templates/ : used for generating the browser extensions
-- release/ : contains the generated packages Dreditor browser extensions.
+- `templates/` : used for generating the browser extensions
+- `release/` : contains the generated packages Dreditor browser extensions.
 
-Both build/ and release/ are added to ```.gitignore``` so make sure these are not added to any PR.
+Both `build/` and `release/` are added to `.gitignore` so make sure these are not added to any PR.
 
 ## Developer workflow
 
 ### Modifying the code
 
 1. Make sure you have Grunt configured correctly as described below.
-1. Run ```grunt watch``` to continues rebuild your changes into the build directory or just ```grunt``` when ready
+1. Run `grunt watch` to continues rebuild your changes into the build directory or just `grunt` when ready
 1. Configure your browser to use the correct build as described below.
 1. Start coding by
   1. Create a (new) feature branch. Please don't work in the `1.x` branch directly.
-  1. Fix the code
+  1. Fix the code. When debugging use `$.debug()` or 'globals' like `window.console` and `window.alert`.
   1. Write a test for the new code
   1. Check the watched output for failing tasks like jslint or tests.
 1. Run `grunt` to ensure code compiles properly. Assuming that you don't see any red, you're ready to go.
@@ -43,7 +43,7 @@ Regarding code style like indentation and whitespace, **follow the conventions y
 
 ### Writing tests
 
-The ```tests/``` directory contains *.html files with are configured to belong to the test and qunit tasks.
+The `tests/` directory contains *.html files with are configured to belong to the test and qunit tasks.
 
 More information coming soon.
 
@@ -53,9 +53,10 @@ More information coming soon.
 
 ### Chrome
 
-1. Navigate to ```chrome://extensions/```
-1. Click on ```Load unpacked extention...```
-1. Browser to the ```build/chrome``` directory and click ```Select```
+1. Navigate to `chrome://extensions/`
+1. Click on `Load unpacked extention...`
+1. Browser to the `build/chrome` directory and click `Select`
+1. Make sure you refresh the extensions page after each code change
 
 ### Firefox
 


### PR DESCRIPTION
I've added lessons learned from @helmo and move some text around

The follow should become separate issues but we ran into these
- [ ] How to work with Firefox
- [ ] How to work with Safari
- [ ] How to install on Ubuntu 12.04
- [ ] Simple patch workflow
- The Chrome workflow is easy as already described.
- While installing on debian we learned the supported packages were not good enough. After installing the node binary in HOME all went ok. Should we document this or add links?
- For writing a single patch we have a steep learning curve. Can we do better?
