### PR TITLE
Feature/window.json

### DIFF
--- a/src/js/extensions/storage.js
+++ b/src/js/extensions/storage.js
@@ -47,7 +47,11 @@ Drupal.storage.load = function (key, bin) {
     return false;
   }
   key = 'Dreditor.' + key;
-  return Drupal.storage.parse(window[bin + 'Storage'].getItem(key));
+  var item = window[bin + 'Storage'].getItem(key);
+  if (item) {
+    return window.JSON.parse(item);
+  }
+  return null;
 };
 
 /**
@@ -82,7 +86,7 @@ Drupal.storage.save = function (key, data, bin) {
     return false;
   }
   key = 'Dreditor.' + key;
-  window[bin + 'Storage'].setItem(key, data);
+  window[bin + 'Storage'].setItem(key, window.JSON.stringify(data));
   return true;
 };
 

--- a/src/js/extensions/storage.js
+++ b/src/js/extensions/storage.js
@@ -36,8 +36,10 @@ Drupal.storage.support = {
  *   (optional) A string denoting the storage space to read from. Defaults to
  *   'local'. See Drupal.storage.save() for details.
  *
+ * @return {any}
+ *   The data stored or null.
+ *
  * @see Drupal.storage.save()
- * @see Drupal.storage.unserialize()
  */
 Drupal.storage.load = function (key, bin) {
   if (typeof bin === 'undefined') {
@@ -62,10 +64,7 @@ Drupal.storage.load = function (key, bin) {
  *   Should be further namespaced by module; e.g., for
  *   "Dreditor.moduleName.settingName" you pass "moduleName.settingName".
  * @param data
- *   The data to store. Note that window storage only supports strings, so data
- *   should be a scalar value (integer, float, string, or Boolean). For
- *   non-scalar values, use Drupal.storage.serialize() before saving and
- *   Drupal.storage.unserialize() after loading data.
+ *   The data to store.
  * @param bin
  *   (optional) A string denoting the storage space to store data in:
  *   - session: Reads from window.sessionStorage. Persists for currently opened
@@ -75,8 +74,9 @@ Drupal.storage.load = function (key, bin) {
  *   - global: Reads from window.globalStorage.
  *   Defaults to 'local'.
  *
+ * @return {Boolean}
+ *   Indicates saving succeded or not.
  * @see Drupal.storage.load()
- * @see Drupal.storage.serialize()
  */
 Drupal.storage.save = function (key, data, bin) {
   if (typeof bin === 'undefined') {

--- a/tests/src/js/extensions/storage.html
+++ b/tests/src/js/extensions/storage.html
@@ -50,6 +50,49 @@
           }
         });
       });
+
+      module('storage');
+      test("Type checks", function() {
+        console.log("=========");
+        var id;
+        var value;
+        var result;
+
+        // We cannot test here for 'array' or 'object'
+        // using qunit equal() so these are separate tests
+        var items = {
+          'number': 42,
+          'string': "Fourtytwo",
+        };
+        jQuery.each(items, function(kind, value) {
+          var id = "QUnit_" + kind;
+          equal(typeof value, kind, "Storing " + kind);
+          Drupal.storage.save(id, value);
+          var result = Drupal.storage.load(id);
+          equal(result, value, "Same value " + kind);
+          ok(result === value, "Identical value " + kind);
+        });
+
+        // Test for array
+        id = "QUnit_array";
+        value = [42];
+        // Array isa Object
+        equal(typeof value, 'object', "Storing array");
+        Drupal.storage.save(id, value);
+        result = Drupal.storage.load(id);
+        console.log(result);
+        // test for first value
+        equal(result[0], value[0], "Retrieved array.");
+
+        id = "QUnit_object";
+        value = {x: 1, y: 2, z: 3};
+        equal(typeof value, 'object', "Storing object");
+        Drupal.storage.save(id, value);
+        result = Drupal.storage.load(id);
+        // equal does not understand objects so test for .x
+        equal(result.x, value.x, "Retrieved object.");
+      });
+
     </script>
   </head>
   <body>


### PR DESCRIPTION
As our browser now have `window.json` why not use is it?
- [ ] Do we still need `Drupal.storage.unserialize()` , `Drupal.storage.serialize()` , `Drupal.storage.parse` ?
