### PR TITLE
Provide ways to store cacheable items

### DIFF
--- a/src/js/extensions/cache.js
+++ b/src/js/extensions/cache.js
@@ -1,0 +1,105 @@
+/**
+ * Mimic of d.o. cache_get cache_set and cache_clear
+ *
+ * Note we only have only a key/value store so there is no cache table.
+ * We store each key/value pair prepending it's key with the cache id.
+ * - cache_node/1 for node id in the default cache
+ */
+Drupal.storage.cache = {
+  /**
+   * Provide a default value if needed
+   *
+   * @param {String} cache
+   *   Cache ID or nothing
+   * @returns {String}
+   *   Cache ID
+   */
+  getCache : function(cache) {
+    return cache ? cache : 'cache';
+  },
+  /**
+   * The key to use for storage.
+   *
+   * @param {String} cache
+   * @param {String} id
+   * @returns {String}
+   */
+  getKey : function(cache, id) {
+    return cache + '_' + id;
+  },
+  /**
+   * List of key for particular cache.
+   *
+   * @param {String} cache
+   * @returns {Array}
+   */
+  getKeys : function(cache) {
+    cache = Drupal.storage.cache.getCache(cache);
+    var keys = Drupal.storage.load(cache);
+    return keys ? keys : [];
+  },
+
+  /**
+   * Store a key/value pair in a particular cache maybe expirable.
+   *
+   * @param {String} id
+   * @param {any} data
+   *   Data item to store
+   * @param {String} cache
+   *   Named cache bin
+   * @param {integer} expire
+   *   Value Data.now() + millisecond or CACHE_PERMANENT === 0
+   *
+   * @see https://api.drupal.org/api/drupal/includes!cache.inc/function/cache_set/7
+   */
+  set : function(id, data, cache, expire) {
+    cache = Drupal.storage.cache.getCache(cache);
+    expire = expire || 0;
+    // Prepend key with it's cache
+    var key = Drupal.storage.cache.getKey(cache, id);
+    // Grab lookup for comparing keys
+    var keys = Drupal.storage.cache.getKeys(cache);
+    if (keys.indexOf(key) === -1) {
+      keys.push(key);
+    }
+    // Save both cachekeys and cachable data @see Drupal.storage.cache
+    var item = {data: data, expire: expire};
+    Drupal.storage.save(key, item);
+    Drupal.storage.save(cache, keys);
+  },
+  /**
+   * Get item from particular cache with given id.
+   *
+   * @param {String} id
+   * @param {String} cache
+   * @returns {any|null}
+   */
+  get : function(id, cache) {
+    cache = Drupal.storage.cache.getCache(cache);
+    var keys = Drupal.storage.cache.getKeys(cache);
+    var key = Drupal.storage.cache.getKey(cache, id);
+    if (keys.indexOf(key) > -1) {
+      var item = Drupal.storage.load(key);
+      if (item.expire === 0 || item.expire > Date.now()) {
+        return item.data;
+      }
+    }
+    return null;
+  },
+  /**
+   * Clears the given (or default) cache
+   *
+   * @param {String|null} cache
+   */
+  clear : function(cache) {
+    cache = Drupal.storage.cache.getCache(cache);
+    var keys = Drupal.storage.cache.getKeys(cache);
+    // Delete data.
+    $.each(keys, function(i, value) {
+      Drupal.storage.remove(value);
+    });
+    // Remove the cache itself.
+    Drupal.storage.remove(cache);
+  }
+}
+;

--- a/src/js/extensions/storage.js
+++ b/src/js/extensions/storage.js
@@ -47,7 +47,11 @@ Drupal.storage.load = function (key, bin) {
     return false;
   }
   key = 'Dreditor.' + key;
-  return Drupal.storage.parse(window[bin + 'Storage'].getItem(key));
+  var item = window[bin + 'Storage'].getItem(key);
+  if (item) {
+    return window.JSON.parse(item);
+  }
+  return null;
 };
 
 /**
@@ -82,7 +86,7 @@ Drupal.storage.save = function (key, data, bin) {
     return false;
   }
   key = 'Dreditor.' + key;
-  window[bin + 'Storage'].setItem(key, data);
+  window[bin + 'Storage'].setItem(key, window.JSON.stringify(data));
   return true;
 };
 

--- a/src/js/extensions/storage.js
+++ b/src/js/extensions/storage.js
@@ -36,8 +36,10 @@ Drupal.storage.support = {
  *   (optional) A string denoting the storage space to read from. Defaults to
  *   'local'. See Drupal.storage.save() for details.
  *
+ * @return {any}
+ *   The data stored or null.
+ *
  * @see Drupal.storage.save()
- * @see Drupal.storage.unserialize()
  */
 Drupal.storage.load = function (key, bin) {
   if (typeof bin === 'undefined') {
@@ -62,10 +64,7 @@ Drupal.storage.load = function (key, bin) {
  *   Should be further namespaced by module; e.g., for
  *   "Dreditor.moduleName.settingName" you pass "moduleName.settingName".
  * @param data
- *   The data to store. Note that window storage only supports strings, so data
- *   should be a scalar value (integer, float, string, or Boolean). For
- *   non-scalar values, use Drupal.storage.serialize() before saving and
- *   Drupal.storage.unserialize() after loading data.
+ *   The data to store.
  * @param bin
  *   (optional) A string denoting the storage space to store data in:
  *   - session: Reads from window.sessionStorage. Persists for currently opened
@@ -75,8 +74,9 @@ Drupal.storage.load = function (key, bin) {
  *   - global: Reads from window.globalStorage.
  *   Defaults to 'local'.
  *
+ * @return {Boolean}
+ *   Indicates saving succeded or not.
  * @see Drupal.storage.load()
- * @see Drupal.storage.serialize()
  */
 Drupal.storage.save = function (key, data, bin) {
   if (typeof bin === 'undefined') {

--- a/tests/src/js/extensions/cache.html
+++ b/tests/src/js/extensions/cache.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='UTF-8' />
+    <meta http-equiv='content-type' content='text/html; charset=utf-8' />
+
+    <title>storage tests</title>
+
+    <script src="http://code.jquery.com/jquery-1.4.4.min.js"></script>
+
+    <script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.12.0.css" type="text/css" media="screen">
+
+    <script>
+      Drupal = {};
+    </script>
+    <script src='../../../../src/js/extensions/storage.js'></script>
+    <script src='../../../../src/js/extensions/cache.js'></script>
+
+    <script>
+      module("Cache support");
+
+      test("Cache clear", function() {
+        var key = "x";
+        var value = 'value-x';
+        var result;
+
+        // Set and Get key using default cache
+        Drupal.storage.cache.set(key, value);
+        equal(Drupal.storage.cache.get(key), value, "Value found.");
+
+        // Clear cache and make sure key is not found
+        Drupal.storage.cache.clear();
+        ok(true, "Default cache cleared");
+        equal(Drupal.storage.cache.get(key), null, "Value not found.");
+
+        // Use a custom cache
+        var cache = 'node';
+
+        // Set and Get key using custom cache
+        Drupal.storage.cache.set(key, value, cache);
+        equal(Drupal.storage.cache.get(key, cache), value, "Value found in cache: " + cache);
+
+        // Clear default cache and make sure key still exists
+        Drupal.storage.cache.clear();
+        equal(Drupal.storage.cache.get(key, cache), value, "Value found in cache: " + cache);
+
+        // Clear custom cache and make sure key is not found
+        Drupal.storage.cache.clear(cache);
+        equal(Drupal.storage.cache.get(key, cache), null, "Value not found.");
+
+      });
+
+      module("Cache expire");
+
+      test("Cache expire test", function() {
+        var id = "expire";
+        var value = "100 milliseconds";
+        var expire = Date.now();
+
+        // Expire item in the past.
+        Drupal.storage.cache.set(id, value, null, expire - 100);
+        equal(Drupal.storage.cache.get(id), null, 'Expired');
+
+        // Never expire item.
+        Drupal.storage.cache.set(id, value, null, 0);
+        equal(Drupal.storage.cache.get(id), value, 'Expired');
+
+        // Expire item in 100 milliseconds.
+        Drupal.storage.cache.set(id, value, null, expire + 100);
+        equal(Drupal.storage.cache.get(id), value, 'Not expired yet');
+        stop();
+        setTimeout(function() {
+          equal(Drupal.storage.cache.get(id), null, 'Expired');
+          start();
+        }, 150);
+
+      });
+
+    </script>
+  </head>
+  <body>
+    <div id="qunit"></div> <!-- QUnit fills this with results, etc -->
+    <div id='qunit-fixture'>
+
+      <!-- any HTML you want to be present in each test (will be reset for each test) -->
+
+    </div>
+  </body>
+</html>
+

--- a/tests/src/js/extensions/storage.html
+++ b/tests/src/js/extensions/storage.html
@@ -50,6 +50,49 @@
           }
         });
       });
+
+      module('storage');
+      test("Type checks", function() {
+        console.log("=========");
+        var id;
+        var value;
+        var result;
+
+        // We cannot test here for 'array' or 'object'
+        // using qunit equal() so these are separate tests
+        var items = {
+          'number': 42,
+          'string': "Fourtytwo",
+        };
+        jQuery.each(items, function(kind, value) {
+          var id = "QUnit_" + kind;
+          equal(typeof value, kind, "Storing " + kind);
+          Drupal.storage.save(id, value);
+          var result = Drupal.storage.load(id);
+          equal(result, value, "Same value " + kind);
+          ok(result === value, "Identical value " + kind);
+        });
+
+        // Test for array
+        id = "QUnit_array";
+        value = [42];
+        // Array isa Object
+        equal(typeof value, 'object', "Storing array");
+        Drupal.storage.save(id, value);
+        result = Drupal.storage.load(id);
+        console.log(result);
+        // test for first value
+        equal(result[0], value[0], "Retrieved array.");
+
+        id = "QUnit_object";
+        value = {x: 1, y: 2, z: 3};
+        equal(typeof value, 'object', "Storing object");
+        Drupal.storage.save(id, value);
+        result = Drupal.storage.load(id);
+        // equal does not understand objects so test for .x
+        equal(result.x, value.x, "Retrieved object.");
+      });
+
     </script>
   </head>
   <body>

--- a/tests/src/js/extensions/storage.html
+++ b/tests/src/js/extensions/storage.html
@@ -6,7 +6,7 @@
 
     <title>storage tests</title>
 
-    <script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
+    <script src="http://code.jquery.com/jquery-1.4.4.min.js"></script>
 
     <script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>
     <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.12.0.css" type="text/css" media="screen">


### PR DESCRIPTION
This patch contains several new features
- Allow for object storage by using `window.JSON.stringify / parse`
- New extension cache with implement similar D7 cache using a keys entry for a use of a particular cache and keys prepended with their cache id.

Now we can cache ie node/124 for further processing like needed for #60 . this opens up to cache all comments and a processed version into another cache.

Patch fixes jQuery version to 1.4.4 as mentioned in #84
