### PR TITLE
Add support for templates (macros)

### DIFF
--- a/src/js/extensions/macro.js
+++ b/src/js/extensions/macro.js
@@ -93,7 +93,7 @@ Drupal.dreditor.macro = {
       type: 'select'
     },
     comment: {
-      id: "edit-comment-body-und-0-value",
+      id: "#edit-comment-body-und-0-value, #edit-nodechanges-comment-body-value",
       type: 'textarea'
     },
     tags: {
@@ -164,7 +164,7 @@ Drupal.dreditor.macro = {
       if (typeof f.readonly !== 'undefined' && f.readonly) {
         return;
       }
-      var $f = jQuery('#' + f.id);
+      var $f = jQuery(f.id);
       // bail out if not defined
       if ($f.length === 0) {
         return;

--- a/src/js/extensions/macro.js
+++ b/src/js/extensions/macro.js
@@ -306,12 +306,12 @@ Drupal.dreditor.macro = {
           }
           else if (cmd === 'duplicate_project') {
             msg = "Please give project name";
-            pattern = 'http://drupal.org/project/@';
+            pattern = 'http://www.drupal.org/project/@';
             def = 'dreditor';
           }
           else if (cmd === 'user_link') {
             msg = "Please give user ID";
-            pattern = 'http://drupal.org/user/@';
+            pattern = 'http://www.drupal.org/user/@';
             def = '0';
           }
           else {

--- a/src/js/extensions/macro.js
+++ b/src/js/extensions/macro.js
@@ -1,0 +1,342 @@
+/**
+ * @defgroup macro
+ * @{
+ */
+
+/**
+ * Dreditor Macro support.
+ *
+ * A macro is just a simple construct @<fieldmame>(set-value)
+ * - @status(3)
+ * - @comment(some text appended)
+ * - @tags(ux)
+ *
+ * To check for field available on a drupal form page this helps a little.
+ * Run it from within firebug.
+ *
+ var list=[];
+ $('#comment-form').find('*[@id]').each(function() {
+ list.push($(this).attr('id'));
+ });
+ list.filter(function(elem){
+ return !elem.match(/wrapper/);
+ });
+ list.join(" ");
+ */
+Drupal.dreditor.macro = {
+  values: {},
+  patterns: {
+    // Make sure patterns match on multiple lines
+    // @user_name(?)
+    query: /^@(.*)\(\?\)$/m,
+    // @user_name()
+    get: /@([a-z_]*)?\(\)/m,
+    // @oldProject() checks the current issue status
+    oldGet: /@old([A-Z][a-z_]*)?\(([^\(\)]*)\)/m,
+    // May contains a get: @comment(This is duplicate of @duplicate_issue())
+    set: /^@([a-z_]+)\(((?:[^\(\)]+\([^\(\)]*\)+|[^\(\)])*)\)/m
+  },
+  /**
+   *
+   * Provide get/set on form field
+   *
+   * Each field is defined by
+   * - id : this is the DOM ID on the page
+   * - type : form type
+   * - label : used for screen scraping when issueing ie oldStatus()
+   *
+   * We support the following types
+   * - text : get/set uses the whole field
+   * - textarea : set appends values
+   * - tags : set handles comma
+   */
+  fields: {
+    title: {
+      id: "edit-title",
+      type: 'text'
+    },
+    project_title: {
+      label: 'Project:',
+      id: "edit-project-info-project-title",
+      type: 'text',
+      hasAjax: true,
+      setFocus: "edit-title"
+    },
+    version: {
+      label: 'Version:',
+      id: "edit-project-info-rid",
+      type: 'select'
+    },
+    assigned: {
+      label: 'Assigned:',
+      id: "edit-project-info-assigned",
+      type: 'select'
+    },
+    component: {
+      label: 'Component:',
+      id: 'edit-project-info-component',
+      type: 'select'
+    },
+    category: {
+      label: 'Category:',
+      id: "edit-category",
+      type: 'select'
+    },
+    priority: {
+      label: 'Priority:',
+      id: "edit-priority",
+      type: 'select'
+    },
+    status: {
+      label: 'Status:',
+      id: "edit-sid",
+      type: 'select'
+    },
+    comment: {
+      id: "edit-comment-body-und-0-value",
+      type: 'textarea'
+    },
+    tags: {
+      label: 'Tags:',
+      id: "edit-taxonomy-tags-9",
+      type: 'tags'
+    }
+  },
+  set: function(name, value) {
+//    function select_set($f, value) {
+//      // First try machine values
+//      window.alert("V '" + value + "'");
+//      var $option_value = $f.find('option[@value=' + value + ']');
+//      if ($option_value.length > 0) {
+//        $f.val($option_value.val());
+//        return;
+//      }
+//      // Try human readable values
+//      var $option_text = $f.find('option')
+//              .filter(function() {
+//                return this.text() === value;
+//              }
+//              );
+//      if ($option_text.length > 0) {
+//        $f.val($option_text.attr('value'));
+//      }
+//    }
+
+    function tags_set($f, value) {
+      var remove = false;
+      if (value.indexOf("-") === 0) {
+        remove = true;
+        value = value.replace(/^\-/, '');
+      }
+      var val = $f.val();
+      var values = [];
+      if (val.length > 0) {
+        values = val.split(/\W*,\W*/);
+      }
+      var position = $.inArray(value, values);
+      if (position > -1) {
+        if (remove) {
+          values.splice(position, 1);
+        }
+      }
+      else {
+        values.push(value);
+      }
+      $f.val(values.join(','));
+    }
+
+    /**
+     * A textarea gets new values appended
+     *
+     * If not empty we prepend new-lines first
+     */
+    function textarea_set($f, value) {
+      var val = $f.val();
+      if (val.length > 0) {
+        $f.val(val + "\n\n" + value);
+        return;
+      }
+      $f.val(value);
+    }
+
+    var f = Drupal.dreditor.macro.fields[name];
+    if (typeof f !== 'undefined') {
+      if (typeof f.readonly !== 'undefined' && f.readonly) {
+        return;
+      }
+      var $f = jQuery('#' + f.id);
+      // bail out if not defined
+      if ($f.length === 0) {
+        return;
+      }
+
+      // If field has ajax side effect move focus away
+      if (f.hasAjax) {
+        $('#' + f.setFocus).focus();
+      }
+      // Apply per field type
+      if (f.type === 'textarea') {
+        textarea_set($f, value);
+      }
+      else if (f.type === 'tags') {
+        tags_set($f, value);
+      }
+      else {
+        $f.val(value);
+      }
+      // Trigger ajax
+      if (f.hasAjax) {
+        $f.blur();
+      }
+    }
+  },
+  /**
+   * The current issue values are presented at the top of an issue
+   *
+   * The values are themed into a table id=project-issue-summary-table
+   *
+   * Each row has two column
+   * - first having the label listed above in the fields
+   * - next having the current issue status value
+   */
+  getCurrent: function(oldName) {
+    var name = oldName.replace(/^old/, '').toLowerCase();
+    var f = Drupal.dreditor.macro.fields[name];
+    if (typeof f !== 'undefined') {
+      if (typeof f.label !== 'undefined') {
+        var label = f.label;
+        var value;
+        var $rows = $('#project-issue-summary-table').find('tr');
+        $.each($rows, function(index, row) {
+          var name = $(row.cells[0]).text();
+          var val = $(row.cells[1]).text();
+          if (name === label) {
+            value = val;
+          }
+        });
+        return value;
+      }
+    }
+  },
+  /**
+   * Get the value of the named field
+   *
+   * @name
+   *   The registered named field
+   * @readable
+   *   The textual variant for select
+   *
+   * @return the machina value or the readable variant
+   */
+  get: function(name, readable) {
+    function select_get($f, readable) {
+      if (readable) {
+        return $f.find('option[@value=' + $f.val() + ']').text();
+      }
+      else {
+        return $f.val();
+      }
+    }
+
+    if (typeof readable === 'undefined') {
+      readable = true;
+    }
+    var f = Drupal.dreditor.macro.fields[name];
+    if (typeof f !== 'undefined') {
+      var $f = jQuery("#" + f.id);
+      // bail out if not defined
+      if ($f.length === 0) {
+        return;
+      }
+      if (f.type === 'select') {
+        return select_get($f, readable);
+      }
+      return $f.val();
+    }
+    else {
+      // Try values
+      return Drupal.dreditor.macro.values[name];
+    }
+  },
+  /**
+   *  Parses a string optional containing macro's
+   *
+   *  Examples
+   *  - needs work @status(13)@tags(documentation)
+   */
+  parse: function(text) {
+    var pattern = Drupal.dreditor.macro.patterns.get;
+    var matches = text.match(pattern);
+    while (matches) {
+      var name = matches[1];
+      text = text.replace(pattern, Drupal.dreditor.macro.get(name));
+      matches = text.match(pattern);
+    }
+    return text;
+  },
+  /**
+   * An array of commands are executed on by one
+   *
+   * Each item may contains more then one macro @id(value)
+   *
+   * @commands array
+   *   Contains strings with macro's
+   */
+  execute: function(commands) {
+    jQuery.each(commands, function(key, value) {
+      window.console.log('Executing: ' + key + ":'" + value + "'");
+      var pattern = Drupal.dreditor.macro.patterns.set;
+      var matches = value.match(pattern);
+      while (matches) {
+        var cmd = matches[1].replace(/^\s*/, '').replace(/\s*$/, '');
+        // trim value
+        var val = matches[2].replace(/^\s*/m, '').replace(/\s*$/m, '');
+        // consume value
+        value = value.replace(pattern, '');
+        if (val === '?') {
+          // Implement a dialog
+          var msg = '';
+          var def = '';
+          pattern = '';
+          if (cmd === 'duplicate_issue' || cmd === 'depends_on_issue' || cmd === 'blocks_issue') {
+            msg = "Please give issue #";
+            pattern = '[#@]';
+            def = '1125936';
+          }
+          else if (cmd === 'duplicate_project') {
+            msg = "Please give project name";
+            pattern = 'http://drupal.org/project/@';
+            def = 'dreditor';
+          }
+          else if (cmd === 'user_link') {
+            msg = "Please give user ID";
+            pattern = 'http://drupal.org/user/@';
+            def = '0';
+          }
+          else {
+            msg = "We need input for " + cmd;
+            pattern = '@';
+            def = '';
+          }
+          if (msg.length) {
+            var result = window.prompt(msg, def);
+
+            result = pattern.replace('@', result);
+            // Store values for later retrieval
+            Drupal.dreditor.macro.values[cmd] = result;
+          }
+        }
+        else {
+          // Process getters like @duplicate_issue() first
+          val = Drupal.dreditor.macro.parse(val);
+          Drupal.dreditor.macro.set(matches[1], val);
+        }
+        matches = value.match(Drupal.dreditor.macro.patterns.set);
+      }
+    });
+  }
+};
+
+/**
+ * @} End of "defgroup macro".
+ */

--- a/src/js/extensions/macro.js
+++ b/src/js/extensions/macro.js
@@ -52,44 +52,44 @@ Drupal.dreditor.macro = {
    */
   fields: {
     title: {
-      id: "edit-title",
+      id: "#edit-title",
       type: 'text'
     },
     project_title: {
       label: 'Project:',
-      id: "edit-project-info-project-title",
+      id: "#edit-field-project-und-0-target-id",
       type: 'text',
       hasAjax: true,
       setFocus: "edit-title"
     },
     version: {
       label: 'Version:',
-      id: "edit-project-info-rid",
+      id: "#edit-field-issue-version-und",
       type: 'select'
     },
     assigned: {
       label: 'Assigned:',
-      id: "edit-project-info-assigned",
+      id: "#edit-field-issue-assigned-und",
       type: 'select'
     },
     component: {
       label: 'Component:',
-      id: 'edit-project-info-component',
+      id: '#edit-field-issue-component-und',
       type: 'select'
     },
     category: {
       label: 'Category:',
-      id: "edit-category",
+      id: "#edit-field-issue-category-und",
       type: 'select'
     },
     priority: {
       label: 'Priority:',
-      id: "edit-priority",
+      id: "#edit-field-issue-priority-und",
       type: 'select'
     },
     status: {
       label: 'Status:',
-      id: "edit-sid",
+      id: "#edit-field-issue-status-und",
       type: 'select'
     },
     comment: {
@@ -98,8 +98,9 @@ Drupal.dreditor.macro = {
     },
     tags: {
       label: 'Tags:',
-      id: "edit-taxonomy-tags-9",
-      type: 'tags'
+      id: "#edit-taxonomy-vocabulary-9-und",
+      type: 'tags',
+      hasAjax: true
     }
   },
   set: function(name, value) {

--- a/src/js/extensions/tabs.js
+++ b/src/js/extensions/tabs.js
@@ -1,0 +1,119 @@
+/**
+ * @defgroup User Experience
+ * @{
+ */
+
+Drupal.dreditor.ux = {
+  /**
+   * tabs provides a tab widget
+   *
+   * First create a container
+   * Next addTabs
+   * Then init
+   * Finally bind
+   */
+  tabs : {
+    /**
+     * Initialize a container holding tabs.
+     *
+     * <div class="dreditor-tabs-container">
+     *   <div class="dreditor-tabs">
+     */
+    createTabContainer : function($container) {
+      $container.empty();
+      var $tabsContainer = $('<div>').addClass('dreditor-tabs-container').appendTo($container);
+      $('<div>').addClass('dreditor-tabs').appendTo($tabsContainer).addClass('active');
+    },
+    /**
+     * Create <div class="dreditor-tab-container dreditor-tab-2 active" id="dreditor-triage">
+     * @param $container
+     *   Container to inject the tabs into
+     * @param tabTitle
+     *   Title to use for the new tab
+     * @param tabID
+     *   unique ID for the the tab and class for its content
+     */
+    addTab : function($container, tabTitle, tabID, content) {
+      var $content = $(content);
+      var $tabsContainer = $('> .dreditor-tabs-container', $container);
+      var $tabs = $('> .dreditor-tabs', $tabsContainer);
+      var $tab = $('<div>').addClass('dreditor-tab').appendTo($tabs).attr('id', tabID);
+      $('<a>').attr('href','#').html(tabTitle).appendTo($tab);
+      var $tabContent = $('<div>').addClass('dreditor-tab-content').appendTo($tabsContainer);
+      $tabContent.addClass(tabID);
+      $content.appendTo($tabContent);
+      // Make last added tab active
+      $('> .dreditor-tab', $tabs).removeClass('active');
+      $tab.addClass('active');
+      $('> .dreditor-tab-content', $tabsContainer).removeClass('active');
+      $tabContent.addClass('active');
+    },
+    /**
+     * Initialise all tabcontainers by setting active and add odd for subtabs.
+     *
+     * A tab container may contain subtabs. Subtabs need a color swap
+     * for better UX.
+     *
+     * We make the top level inactive so it is collapsed. This preserve screen space.
+     */
+    init : function() {
+      $('.dreditor-tabs-container').each(function() {
+        var $this = $(this);
+        // It this a sub tab container?
+        var depth = $this.parents('.dreditor-tabs-container').size();
+        var odd = ((depth % 2) == 1);
+        if (odd) {
+          $this.addClass('odd');
+          $('> .dreditor-tabs', $this).addClass('odd');
+          $('> .dreditor-tab-content', $this).addClass('odd');
+        }
+        else {
+          $this.removeClass('odd');
+          $('> .dreditor-tabs', $this).removeClass('odd');
+          $('> .dreditor-tab-content', $this).removeClass('odd');
+        }
+        // Preserve screenspace
+        if (depth == 0) {
+          $this.removeClass('active');
+          $('> .dreditor-tabs', $this).removeClass('active');
+          $('> .dreditor-tabs > .dreditor-tab', $this).removeClass('active');
+          $('> .dreditor-tab-content', $this).removeClass('active');
+        }
+      });
+    },
+    /**
+     * Bind the click event to the tabs.
+     *
+     * Each tab is connected to its content by mapping it's ID to content class
+     */
+    bind : function() {
+      $('.dreditor-tab > a').click(function(){
+        var $tab = $(this).parent();
+        var $tabs = $tab.parent();
+        var $tabsContainer = $tabs.parent();
+        var tabId = $tab.attr('id');
+        var $content = $('.dreditor-tab-content.' + tabId, $tabsContainer);
+        // We hide current active tab
+        if ($tab.hasClass('active')) {
+          $tabs.removeClass('active');
+          $tab.removeClass('active');
+          $content.removeClass('active');
+        }
+        else {
+          $tabs.addClass('active');
+          // Only change current level elements
+          $('> .dreditor-tab', $tabs).removeClass('active');
+          $tab.addClass('active');
+          $('> .dreditor-tab-content', $tabsContainer).removeClass('active');
+          $content.addClass('active');
+        }
+        return false;
+      });
+    }
+  }
+}
+
+/**
+ * @} End of "defgroup User Experience".
+ */
+

--- a/src/js/extensions/tabs.js
+++ b/src/js/extensions/tabs.js
@@ -1,3 +1,6 @@
+Drupal = Drupal || {};
+Drupal.dreditor = Drupal.dreditor || {};
+
 /**
  * @defgroup User Experience
  * @{
@@ -18,6 +21,9 @@ Drupal.dreditor.ux = {
      *
      * <div class="dreditor-tabs-container">
      *   <div class="dreditor-tabs">
+     *
+     * @param {jQuery} $container
+     * @returns {nothing}
      */
     createTabContainer : function($container) {
       $container.empty();
@@ -61,7 +67,7 @@ Drupal.dreditor.ux = {
         var $this = $(this);
         // It this a sub tab container?
         var depth = $this.parents('.dreditor-tabs-container').size();
-        var odd = ((depth % 2) == 1);
+        var odd = ((depth % 2) === 1);
         if (odd) {
           $this.addClass('odd');
           $('> .dreditor-tabs', $this).addClass('odd');
@@ -73,7 +79,7 @@ Drupal.dreditor.ux = {
           $('> .dreditor-tab-content', $this).removeClass('odd');
         }
         // Preserve screenspace
-        if (depth == 0) {
+        if (depth === 0) {
           $this.removeClass('active');
           $('> .dreditor-tabs', $this).removeClass('active');
           $('> .dreditor-tabs > .dreditor-tab', $this).removeClass('active');
@@ -111,7 +117,7 @@ Drupal.dreditor.ux = {
       });
     }
   }
-}
+};
 
 /**
  * @} End of "defgroup User Experience".

--- a/src/js/extensions/tabs.js
+++ b/src/js/extensions/tabs.js
@@ -1,6 +1,3 @@
-Drupal = Drupal || {};
-Drupal.dreditor = Drupal.dreditor || {};
-
 /**
  * @defgroup User Experience
  * @{

--- a/src/js/extensions/tabs.js
+++ b/src/js/extensions/tabs.js
@@ -119,4 +119,3 @@ Drupal.dreditor.ux = {
 /**
  * @} End of "defgroup User Experience".
  */
-

--- a/src/js/extensions/tabs.js
+++ b/src/js/extensions/tabs.js
@@ -1,3 +1,6 @@
+Drupal = Drupal || {};
+Drupal.dreditor = Drupal.dreditor || {};
+
 /**
  * @defgroup User Experience
  * @{

--- a/src/js/plugins/commit.message.js
+++ b/src/js/plugins/commit.message.js
@@ -223,9 +223,6 @@ Drupal.behaviors.dreditorCommitMessage = {
         return false;
       });
 
-      // Add margin from tags field
-      $container.css('margin-top', '20px');
-
       var tabs = Drupal.dreditor.ux.tabs;
       tabs.createTabContainer($container);
       tabs.addTab($container, 'Macro &amp; Templates', 'dreditor-triage-root', $('<p>').text('Replaced by sub tabs'));

--- a/src/js/plugins/commit.message.js
+++ b/src/js/plugins/commit.message.js
@@ -165,7 +165,7 @@ Drupal.behaviors.dreditorCommitMessage = {
             return command;
           };
           var $commandContainer = $('<div id="dreditor-commitmessage-command" style="clear: both; padding: 1em 0;" />')
-            .appendTo($container);
+            .appendTo($root);
           var $commandInput = $('<input class="dreditor-input" type="text" autocomplete="off" />')
             .val(self.createShellCommand(message));
 
@@ -222,6 +222,10 @@ Drupal.behaviors.dreditorCommitMessage = {
         }
         return false;
       });
+
+      // Add margin from tags field
+      $container.css('margin-top', '20px');
+
       var tabs = Drupal.dreditor.ux.tabs;
       tabs.createTabContainer($container);
       tabs.addTab($container, 'Macro &amp; Templates', 'dreditor-triage-root', $('<p>').text('Replaced by sub tabs'));

--- a/src/js/plugins/commit.message.js
+++ b/src/js/plugins/commit.message.js
@@ -222,7 +222,22 @@ Drupal.behaviors.dreditorCommitMessage = {
         }
         return false;
       });
-      $link.prependTo($container);
+      var tabs = Drupal.dreditor.ux.tabs;
+      tabs.createTabContainer($container);
+      tabs.addTab($container, 'Macro &amp; Templates', 'dreditor-triage-root', $('<p>').text('Replaced by sub tabs'));
+      tabs.addTab($container, 'Commit message', 'dreditor-commit-message-root', $('<p>').text('Replaced by sub tabs'));
+      tabs.init();
+      tabs.bind();
+
+      // Zap the div
+      var $root = $('.dreditor-tab-content.dreditor-commit-message-root').empty();
+      $link.prependTo($root);
+      // Fix for floating link.
+      $link.wrap('<div>').css('float', 'none');
+      var $commit = $link.parent();
+      $commit.css('text-align', 'right');
+
+      Drupal.dreditor.triage.setup($container);
     });
   }
 };

--- a/src/js/plugins/issue.js
+++ b/src/js/plugins/issue.js
@@ -64,7 +64,7 @@ Drupal.dreditor.issue = {
       type : 'tags'
     },
     comment : {
-      id : "edit-comment-body-und-0-value",
+      id : "edit-comment-body-und-0-value, #edit-nodechanges-comment-body-value",
       type : 'textarea'
     }
   },

--- a/src/js/plugins/issue.js
+++ b/src/js/plugins/issue.js
@@ -64,7 +64,7 @@ Drupal.dreditor.issue = {
       type : 'tags'
     },
     comment : {
-      id : "edit-comment",
+      id : "edit-comment-body-und-0-value",
       type : 'textarea'
     }
   },

--- a/src/js/plugins/issue.js
+++ b/src/js/plugins/issue.js
@@ -1,4 +1,98 @@
-Drupal.dreditor.issue = {};
+Drupal = Drupal || {};
+Drupal.dreditor = Drupal.dreditor || {};
+
+Drupal.dreditor.issue = {
+  /**
+   * List of values available on issue view or edit page.
+   *
+   * @type object
+   */
+  fields : {
+    title : {
+      id : "edit-title",
+      get: "#page-subtitle",
+      type : 'text'
+    },
+    status : {
+      label : 'Status:',
+      get: '#block-project-issue-issue-metadata .field-name-field-issue-status .field-items',
+      id : "edit-sid",
+      type : 'select'
+    },
+    project_title : {
+      label : 'Project:',
+      get : '#block-project-issue-issue-metadata .field-name-field-project .field-items ',
+      id : "edit-project-info-project-title",
+      type : 'text',
+      hasAjax : true,
+      setFocus: "edit-title"
+    },
+    version : {
+      label : 'Version:',
+      get : '#block-project-issue-issue-metadata .field-name-field-issue-version .field-items ',
+      id : "edit-project-info-rid",
+      type : 'select'
+    },
+    component : {
+      label : 'Component:',
+      get : '#block-project-issue-issue-metadata .field-name-field-issue-component .field-items ',
+      id : 'edit-project-info-component',
+      type : 'select'
+    },
+    priority : {
+      label : 'Priority:',
+      get : '#block-project-issue-issue-metadata .field-name-field-issue-priority .field-items ',
+      id : "edit-priority",
+      type : 'select'
+    },
+    category : {
+      label : 'Category:',
+      get : '#block-project-issue-issue-metadata .field-name-field-issue-category .field-items ',
+      id : "edit-category",
+      type : 'select'
+    },
+    assigned : {
+      label : 'Assigned:',
+      get : '#block-project-issue-issue-metadata .field-name-field-issue-assigned .field-items ',
+      id : "edit-project-info-assigned",
+      type : 'select'
+    },
+    tags : {
+      label : 'Tags:',
+      get: '#block-project-issue-issue-metadata .field-name-taxonomy-vocabulary-9 .field-items .field-item',
+      id : "edit-taxonomy-tags-9",
+      type : 'tags'
+    },
+    comment : {
+      id : "edit-comment",
+      type : 'textarea'
+    }
+  },
+  /**
+   * The current issue values are presented at the top of an issue
+   *
+   * The values are themed into a table id=project-issue-summary-table
+   *
+   * Each row has two column
+   * - first having the label listed above in the fields
+   * - next having the current issue status value
+   */
+  getCurrent : function (oldName) {
+    var name = oldName.replace(/^old/, '').toLowerCase();
+    var f = Drupal.dreditor.issue.fields[name];
+    if (typeof f !== 'undefined') {
+      if (typeof f.label !== 'undefined') {
+        var value = [];
+        $(f.get).each(function(){
+          value.push($(this).text());
+        });
+        return value.join(', ');
+      }
+    }
+    return '';
+  },
+};
+
 /**
  * Gets the issue node id.
  */
@@ -23,8 +117,7 @@ Drupal.dreditor.issue.getNewCommentNumber = function() {
  * Gets the issue title.
  */
 Drupal.dreditor.issue.getIssueTitle = function() {
-  var title = $('#page-subtitle').text() || '';
-  return title;
+  return Drupal.dreditor.issue.getCurrent('title');
 };
 
 /**
@@ -80,8 +173,7 @@ Drupal.dreditor.issue.getSelectedComponent = function() {
  */
 Drupal.dreditor.issue.getSelectedVersion = function() {
   // Retrieve version from the comment form selected option label.
-  var version = $(':input[name*="issue_version"] :selected').text();
-  return version;
+  return Drupal.dreditor.issue.getCurrent('version');
 };
 
 /**

--- a/src/js/plugins/issue.js
+++ b/src/js/plugins/issue.js
@@ -117,8 +117,7 @@ Drupal.dreditor.issue.getNewCommentNumber = function() {
  * Gets the issue title.
  */
 Drupal.dreditor.issue.getIssueTitle = function() {
-  var title = $('#page-subtitle').text() || '';
-  return title;
+  return Drupal.dreditor.issue.getCurrent('title');
 };
 
 /**

--- a/src/js/plugins/issue.js
+++ b/src/js/plugins/issue.js
@@ -117,7 +117,8 @@ Drupal.dreditor.issue.getNewCommentNumber = function() {
  * Gets the issue title.
  */
 Drupal.dreditor.issue.getIssueTitle = function() {
-  return Drupal.dreditor.issue.getCurrent('title');
+  var title = $('#page-subtitle').text() || '';
+  return title;
 };
 
 /**

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -136,9 +136,9 @@ Drupal.dreditor.triage = {
     var $ul = $('<ul id="dreditor-triage-menu">');
 
     // TODO: remove next lines when committing to dreditor
-    var $li = $('<li><strong><a href="http://drupal.org/sandbox/clemenstolboom/1125712">Using sandboxed version</a></strong></li>');
+    var $li = $('<li><strong><a href="https://github.com/dreditor/dreditor/pull/93">Using PR version</a></strong></li>');
     $li.appendTo($ul);
-    $li = $('<li><strong><a href="http://drupalcode.org/project/dreditor.git/blob_plain/HEAD:/dreditor.user.js">Use original dreditor</a></strong></li>');
+    $li = $('<li><strong><a href="https://dreditor.org/">Switch back to original dreditor</a></strong></li>');
     $li.appendTo($ul);
     // TODO: END remove above lines
 

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -93,7 +93,7 @@ Drupal.dreditor.triage = {
   getTriageRoot : function() {
     return {
       id : 'node-1120672',
-      url : "//drupal.org/node/1120672",
+      url : "//www.drupal.org/node/1120672",
       description : 'The root for all triage nodes'
     };
   },
@@ -187,7 +187,7 @@ Drupal.dreditor.triage = {
       .appendTo($li)
       .click(function() {
         var custom = window.prompt('Give the URL of your custom DL tree.' +
-          "\n\n" + 'This URL must point to a location on http://drupal.org' +
+          "\n\n" + 'This URL must point to a location on http://www.drupal.org' +
           "\n\n" + 'See http://en.wikipedia.org/wiki/Same_origin_policy', Drupal.storage.load('triage-custom'));
         if (custom) {
           Drupal.storage.save('triage-custom', custom);
@@ -354,7 +354,7 @@ Drupal.dreditor.triage = {
         var source = {
           id: $this.attr('href').replace(/^\//,'').replace(/\//g,'-'),
           url: $this.attr('href'),
-          // Cleanup description per http://drupal.org/node/1287934
+          // Cleanup description per http://www.drupal.org/node/1287934
           description: $this.text().replace(/\s*\[.*/, '').replace('dreditor_' , '')
         };
         sources.push(source);
@@ -473,7 +473,7 @@ Drupal.dreditor.triage = {
         if (!Drupal.dreditor.triage.bannerInjected) {
           Drupal.dreditor.triage.bannerInjected = true;
           // We reuse the DT text for generating a stock response
-          var stockResponse = '[Stock response from <a href="http://drupal.org/node/1120672">Dreditor templates and macros</a>.]';
+          var stockResponse = '[Stock response from <a href="http://www.drupal.org/node/1120672">Dreditor templates and macros</a>.]';
           actions.push('@comment(' + stockResponse + ')');
         }
         // Grab all actions up the tree

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -314,25 +314,15 @@ Drupal.dreditor.triage = {
     $container.css('overflow', 'visible');
     // Add margin from tags field
     $container.css('margin-top', '20px');
-    var tabs = Drupal.dreditor.ux.tabs;
-    tabs.createTabContainer($container);
-//    $link.wrap('<p>').css('float', 'none');
-//    var $commit = $link.parent();
-//    $commit.css('text-align', 'right');
-//    tabs.addTab($container, 'Commit message', 'id-1', $commit);
-    tabs.addTab($container, 'Macro &amp; Templates', 'dreditor-triage-root', $('<p>').text('Replaced by sub tabs'));
-
-    $('.dreditor-tab-content.dreditor-triage-root').empty();
-//    Drupal.dreditor.triage.setup($content);
-    tabs.init();
-    tabs.bind();
+    // Zap the div
+    var $root = $('.dreditor-tab-content.dreditor-triage-root').empty();
 
     var $triage = $('#dreditor-triage');
     if ($triage.length === 0) {
       // First time call so setup
       $triage = $('<div id="dreditor-triage" style="width: 95%">');
       //$triage.prependTo($container.parent());
-      $triage.appendTo($container);
+      $triage.appendTo($root);
       $triage.css('overflow', 'initial');
     }
     // We rebuild the container

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -312,8 +312,6 @@ Drupal.dreditor.triage = {
    */
   setup : function($container) {
     $container.css('overflow', 'visible');
-    // Add margin from tags field
-    $container.css('margin-top', '20px');
     // Zap the div
     var $root = $('.dreditor-tab-content.dreditor-triage-root').empty();
 

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -311,10 +311,25 @@ Drupal.dreditor.triage = {
    *   We stuff the layout before the given $container
    */
   setup : function($container) {
+    $container.css('overflow', 'visible');
+    // Add margin from tags field
+    $container.css('margin-top', '20px');
+    var tabs = Drupal.dreditor.ux.tabs;
+    tabs.createTabContainer($container);
+//    $link.wrap('<p>').css('float', 'none');
+//    var $commit = $link.parent();
+//    $commit.css('text-align', 'right');
+//    tabs.addTab($container, 'Commit message', 'id-1', $commit);
+    tabs.addTab($container, 'Macro &amp; Templates', 'dreditor-triage-root', $('<p>').text('Replaced by sub tabs'));
+
+    $('.dreditor-tab-content.dreditor-triage-root').empty();
+//    Drupal.dreditor.triage.setup($content);
+    tabs.init();
+    tabs.bind();
+
     var $triage = $('#dreditor-triage');
     if ($triage.length === 0) {
       // First time call so setup
-      Drupal.dreditor.triage.injectCSS();
       $triage = $('<div id="dreditor-triage" style="width: 95%">');
       //$triage.prependTo($container.parent());
       $triage.appendTo($container);

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -93,7 +93,7 @@ Drupal.dreditor.triage = {
   getTriageRoot : function() {
     return {
       id : 'node-1120672',
-      url : "//www.drupal.org/node/1120672",
+      url : "/node/1120672",
       description : 'The root for all triage nodes'
     };
   },

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -1,0 +1,523 @@
+Drupal = Drupal || {};
+Drupal.dreditor = Drupal.dreditor || {};
+
+//    //    // Prepend commit message button to comment form.
+//    // @todo Generalize this setup. Somehow.
+//    if (!$container.length) {
+//      $container = $('<div class="dreditor-actions" style="width: 95%"></div>');
+//      $(this).prepend($container);
+//    }
+//
+//    $container.css('overflow', 'visible');
+//    // Add margin from tags field
+//    $container.css('margin-top', '20px');
+//    var tabs = Drupal.dreditor.ux.tabs;
+//    tabs.createTabContainer($container);
+//    $link.wrap('<p>').css('float', 'none');
+//    var $commit = $link.parent();
+//    $commit.css('text-align', 'right');
+//    tabs.addTab($container, 'Commit message', 'id-1', $commit);
+//    tabs.addTab($container, 'Macro &amp; Templates', 'dreditor-triage-root', $('<p>').text('Replaced by sub tabs'));
+//
+//    // Inject triage
+//    var $content = $('.dreditor-tab-content.dreditor-triage-root').empty();
+//    Drupal.dreditor.triage.setup($content);
+//    tabs.init();
+//    tabs.bind();
+//    tabs.injectCSS();
+//  });
+//};
+
+/**
+ * Placeholder for managing triage or issue management
+ *
+ * We have the source pages on d.o which are loaded through a cache handler.
+ * The pages containing a DL are processed into UL which contain commands
+ * to manage an issue on d.o
+ */
+Drupal.dreditor.triage = {
+  /**
+   * We need some CSS injected into the current page
+   *
+   * Colors are based on bluecheese http://groups.drupal.org/node/56698 colors
+   * - Dark blue  : #0678be
+   * - Light blue : #53b0eb
+   * - White      : #eee?
+   */
+  injectCSS : function() {
+    window.alert('css not injected');
+    $('head').append();
+  },
+  /**
+   * Getter for hideIrrelevant
+   */
+  getHideIrrelevant : function() {
+    var current = Drupal.storage.load('triage-hide-irrelevant');
+    if (typeof current === 'undefined') {
+      current = false;
+      Drupal.storage.save('triage-hide-irrelevant', current);
+    }
+    return current;
+  },
+  /**
+   * Setter for hideIrrelevant
+   *
+   * @param current
+   *   current state of irrelevancy
+   */
+  setHideIrrelevant : function(current) {
+    Drupal.storage.save('triage-hide-irrelevant', current);
+    return current;
+  },
+  /**
+   * Give user possibility to hide irrelevant options.
+   *
+   * This is usefull when having a lot of issue state change options.
+   * Not all options are relavant with respect to the current state.
+   * 
+   * @param {type} toggle
+   * @returns {any|Boolean|Drupal.dreditor.triage.getHideIrrelevant.current|Drupal.dreditor.triage.hideIrrelevant.current}
+   */
+  hideIrrelevant : function(toggle) {
+    if (typeof toggle === 'undefined') {
+      toggle = true;
+    }
+    var current = Drupal.dreditor.triage.getHideIrrelevant();
+    if (toggle) {
+      current = !current;
+    }
+
+    if (current) {
+      $('.triage-top-level').addClass('triage-hide-irrelevant');
+    }
+    else {
+      $('.triage-top-level').removeClass('triage-hide-irrelevant');
+    }
+
+    Drupal.dreditor.triage.setHideIrrelevant(current);
+    return current;
+  },
+  /**
+   * The root book page containing triage child pages
+   *
+   * For now we only use the child pages of the root
+   *
+   * We could use the hierarchy later on to add project
+   * specific sub Macro and Templates
+   */
+  getTriageRoot : function() {
+    return {
+      id : 'node-1120672',
+      url : "//drupal.org/node/1120672",
+      description : 'The root for all triage nodes'
+    };
+  },
+  /**
+   * Downloads a file and then store it for later reuse
+   *
+   * As we can only get data from the same domain
+   * we better log bad requests to help our users.
+   *
+   * So in our tests we populate the cache so bypass this.
+   *
+   * @see http://en.wikipedia.org/wiki/Same_origin_policy
+   */
+  getFile : function(id, src, callback) {
+    var data = Drupal.cache.get(id, 'triage');
+    if (data) {
+      window.console.log("getFile: cache hit: " + id);
+      callback(data);
+    }
+    else {
+      window.console.log("getFile: cache miss: " + id);
+      $.ajax({
+        url : src,
+        success: function(data) {
+          Drupal.cache.set(id, data, 'triage');
+          callback(data);
+        },
+        dataType: 'html'
+      });
+    }
+
+  },
+  /**
+   * The menu for triage
+   */
+  menu : function() {
+    var $triageOptions = $('#dreditor-triage-options');
+    $triageOptions.css('float', 'right');
+
+    var $ul = $('<ul id="dreditor-triage-menu">');
+
+    // TODO: remove next lines when committing to dreditor
+    var $li = $('<li><strong><a href="http://drupal.org/sandbox/clemenstolboom/1125712">Using sandboxed version</a></strong></li>');
+    $li.appendTo($ul);
+    $li = $('<li><strong><a href="http://drupalcode.org/project/dreditor.git/blob_plain/HEAD:/dreditor.user.js">Use original dreditor</a></strong></li>');
+    $li.appendTo($ul);
+    // TODO: END remove above lines
+
+    $li = $('<li>');
+    $li.appendTo($ul);
+    var $action = $('<a>')
+      .attr('href', '#').text('Reset')
+      .appendTo($li)
+      .click(function() {
+        Drupal.cache.clear('triage');
+        $('#dreditor-triage-list').empty();
+        var $triage = $('#dreditor-triage');
+        $triage.empty();
+        var $container = $triage.parent();
+        Drupal.dreditor.triage.setup($container);
+        return false;
+      }
+    );
+    $li = $('<li>');
+    $li.appendTo($ul);
+    $action = $('<a>')
+      .attr('href', '#')
+      .appendTo($li)
+      .click(function() {
+        Drupal.dreditor.triage.hideIrrelevant();
+        if (Drupal.dreditor.triage.getHideIrrelevant()) {
+          $(this).text('Show irrelevant');
+        }
+        else {
+          $(this).text('Hide irrelevant');
+        }
+        return false;
+      }
+    );
+    // When clicking we toggle the value so pre-toggle to prevent corrupting
+    Drupal.dreditor.triage.setHideIrrelevant(!Drupal.dreditor.triage.getHideIrrelevant());
+    //Click on the action to prepare its state.
+    $action.click();
+
+    $li = $('<li>');
+    $li.appendTo($ul);
+    $action = $('<a>')
+      .attr('href', '#').text('Set custom source')
+      .appendTo($li)
+      .click(function() {
+        var custom = window.prompt('Give the URL of your custom DL tree.' +
+          "\n\n" + 'This URL must point to a location on http://drupal.org' +
+          "\n\n" + 'See http://en.wikipedia.org/wiki/Same_origin_policy', Drupal.storage.load('triage-custom'));
+        if (custom) {
+          Drupal.storage.save('triage-custom', custom);
+        }
+        else {
+          Drupal.storage.remove('triage-custom');
+        }
+        Drupal.dreditor.triage.setup();
+        // TODO: As personal sources are to be trusted we could allow for more automation
+        return false;
+      }
+    );
+    $ul.hide().appendTo($triageOptions);
+    var $img = $('<a class="dreditor-application-toggle dreditor-commitmessage" href="#">Config Macro &amp; Templates</a>');
+    $img.prependTo($triageOptions);
+    $img.click(function(){
+      $ul.toggle('slow');
+      return false;
+    });
+  },
+  /**
+   * Add the tabs for different triage sources / nodes
+   *
+   * All except the custom node are supposed to come from the triage root nodes
+   * 
+   * @param {type} sources
+   * @returns {undefined}
+   */
+  tabs : function(sources) {
+    // Get the current project title to decide to show its stock responses.
+    var currentProject = Drupal.dreditor.macro.getCurrent('project_title');
+    var $ul = $('<ul>').addClass('dreditor-triage-full-list');
+    $ul.appendTo('#dreditor-triage-list');
+
+    // Only allow sources matching Default, Custom and Current project
+    $.each(sources, function(source) {
+      var sourceProject = sources[source].description;
+      if (!(sourceProject === '_default' || sourceProject === "_custom" || sourceProject === currentProject)) {
+                window.console.log('Skipping project "' + sourceProject +'"');
+        return;
+      }
+      var label = sources[source].description;
+      var $link = $('<li><a href="#">' + label + '</a></li>');
+      $link.appendTo($ul);
+      $link.click( function() {
+        var $this = $(this);
+        var $that = $this;
+        if ($this.hasClass('get-processed')) {
+          return false;
+        }
+        $this.addClass('get-processed');
+        // Generate options list
+        var src = sources[source].url;
+        var id = sources[source].id;
+        var label = sources[source].description;
+
+        var ajaxSuccess = function(data) {
+          var $placeholder = $that;
+          // Find the first dl on the page
+          var $dl = $(data).find('dl:first');
+          /*
+           * We need to fix input format quirks
+           *
+           * Here we fix project issue [#1234567]
+           */
+          $('.project-issue-status-info > a', $dl).each(function() {
+            var $this =$(this);
+            var m = $this.text().match(/^#([0-9]+):/);
+            if (m) {
+              $this.parent().replaceWith('[#' + m[1] + ']');
+            }
+          });
+          Drupal.dreditor.triage.parseDefinitionList($placeholder, $dl);
+          Drupal.dreditor.triage.decorateList($('ul:first', $placeholder));
+
+          var $options = $("#dreditor-triage-list");
+          // The menu float right so we need to make sure the are not block by the macro's'
+          $options.css('width', '75%');
+
+          $placeholder.find('li').addClass('triage-not-in-context');
+          // Remove not-in-context from self and parents of in-context
+          $placeholder.find('li.triage-in-context').
+            removeClass('triage-not-in-context').
+            parents().
+            removeClass('triage-not-in-context')
+          ;
+          // Place children into context
+          $placeholder.
+            find('li.triage-in-context li').
+            removeClass('triage-not-in-context')
+          ;
+          Drupal.dreditor.triage.hideIrrelevant(false);
+          // Add view and edit links to the bottom of the list to the source.
+          var $top = $('ul.level-1', $placeholder);
+          var $linkT = $('<li>').appendTo($top).addClass('source');
+          // Link to Source
+          $('<a>')
+            .text('view')
+            .attr('href', src = sources[source].url)
+            .attr('title', 'View the ' + label + ' set of templates and macros.')
+            .attr('target', '_blank')
+            .appendTo($linkT)
+          ;
+          $('<span> or </span>').appendTo($linkT);
+          // Link to edit
+          $('<a>')
+            .text('edit')
+            .attr('href', src = sources[source].url + '/edit')
+            .attr('title', 'Edit the ' + label + ' set of templates and macros.')
+            .attr('target', '_blank')
+            .appendTo($linkT)
+          ;
+        };
+        Drupal.dreditor.triage.getFile(id, src, ajaxSuccess);
+        return false;
+      });
+    });
+  },
+  /**
+   * Build the triage container
+   *
+   * @param $container (optional)
+   *   We stuff the layout before the given $container
+   */
+  setup : function($container) {
+    var $triage = $('#dreditor-triage');
+    if ($triage.length === 0) {
+      // First time call so setup
+      Drupal.dreditor.triage.injectCSS();
+      $triage = $('<div id="dreditor-triage" style="width: 95%">');
+      //$triage.prependTo($container.parent());
+      $triage.appendTo($container);
+      $triage.css('overflow', 'initial');
+    }
+    // We rebuild the container
+    $triage.empty();
+    $('<div id="dreditor-triage-options">').appendTo($triage);
+    //$('<div id="dreditor-triage-tabs">').appendTo($triage);
+    $('<div id="dreditor-triage-list">').appendTo($triage);
+
+    Drupal.dreditor.triage.menu();
+
+    var $triages = $('<div>');
+    $triages.css('clear', 'right');
+    $triages.appendTo($triage);
+    // Prevent injecting banner multiple times
+    Drupal.dreditor.triage.bannerInjected = false;
+
+    var root = Drupal.dreditor.triage.getTriageRoot();
+    Drupal.dreditor.triage.getFile(root.id, root.url, function(data) {
+      var sources = [];
+      var $links = $('.book-navigation ul:first li a', $(data));
+      $links.each(function(){
+        var $this = $(this);
+        var source = {
+          id: $this.attr('href').replace(/^\//,'').replace(/\//g,'-'),
+          url: $this.attr('href'),
+          // Cleanup description per http://drupal.org/node/1287934
+          description: $this.text().replace(/\s*\[.*/, '').replace('dreditor_' , '')
+        };
+        sources.push(source);
+      });
+      // Add custom source
+      var custom_url = Drupal.storage.load('triage-custom');
+      if (custom_url) {
+        var source = {
+          id: 'triage-custom-content',
+          url: custom_url,
+          description: '_custom'
+        };
+        sources.push(source);
+      }
+      Drupal.dreditor.triage.tabs(sources);
+    });
+  },
+
+  /**
+   * We want to make the list look like the same as on d.o
+   *
+   * @param $ul
+   *   The unorder list of menu items.
+   */
+  decorateList : function( $ul) {
+    $('ul', $ul).hide();
+    // Make compatible with d.o indicating child li's
+    $ul.find('li').removeClass('collapsed').parents('li').addClass('collapsed');
+
+    $("li.collapsed", $ul).hover(
+      function(){
+        var $this = $(this);
+        $this.removeClass('collapsed').addClass('expanded');
+        $this.children('ul:first').css('z-index', 1000).show();
+      },
+      function(){
+        var $this = $(this);
+        $this.addClass('collapsed').removeClass('expanded');
+        $this.children('ul:first').hide().css('z-index', -1);
+      }
+    );
+  },
+
+  /**
+   * Process a d.o. DL tree
+   *
+   * @param $container
+   *   Were to put the result
+   * @param $dl
+   *   A (valid) DL jquery tree
+   * @param level
+   *   Indicates the depth within the tree
+   */
+  parseDefinitionList : function($container, $dl, level) {
+    if (typeof level === 'undefined') {
+      level = 1;
+      $container.addClass('triage-top-level');
+    }
+    var $ul = $('<ul>').addClass('level-' + level);
+    $ul.appendTo($container);
+    $dl.children('dt').each(function() {
+      // a 'dt' may contain macros: we split on the first '@'
+      var $dt = $(this);
+      var ts = $dt.text().split('@');
+      var commands ='';
+      var executableCommands = [];
+      var inContext = false;
+      if (ts.length) {
+        $dt.text(ts.shift());
+        if (ts.length) {
+          // We have commands so keep them to show on hover
+          commands = '@' + ts.join('@');
+          // Are we inContext (this is an AND on all oldValues
+          var oldGetCount = 0;
+          inContext = false;
+          $.each(ts, function(index, value) {
+            var matches;
+            value = '@' + value;
+            matches = value.match(Drupal.dreditor.macro.patterns.oldGet);
+            if (matches) {
+              if (oldGetCount === 0) {
+                // First oldGet so potentially inContext
+                inContext = true;
+                oldGetCount++;
+              }
+              var field = matches[1];
+              var val = matches[2];
+              var currentVal = Drupal.dreditor.macro.getCurrent(field);
+              if (val !== currentVal) {
+                inContext = false;
+              }
+            }
+            else {
+              executableCommands.push(value);
+            }
+          });
+        }
+      }
+      var $dtl = $('<li>');
+      if (inContext) {
+        $dtl.addClass('triage-in-context active-trail');
+      }
+      var $action = $('<a class="triage-action">').attr('href', '#');
+      $action.data('triage-commands', []);
+      $action.appendTo($dtl);
+      $('<span class="triage-commands">' + $dt.text() + '</span>').appendTo($action);
+      if (commands) {
+        $action.attr('title', commands);
+        $(executableCommands).each(function(index, value) {
+          $action.data('triage-commands').push(value);
+        });
+      }
+      $action.click(function() {
+        var $this = $(this);
+        var actions = [];
+        if (!Drupal.dreditor.triage.bannerInjected) {
+          Drupal.dreditor.triage.bannerInjected = true;
+          // We reuse the DT text for generating a stock response
+          var stockResponse = '[Stock response from <a href="http://drupal.org/node/1120672">Dreditor templates and macros</a>.]';
+          actions.push('@comment(' + stockResponse + ')');
+        }
+        // Grab all actions up the tree
+        $this.parents().each(function() {
+          var $action = $(this).children('a.triage-action:first');
+          var commands = $action.data('triage-commands');
+          if (commands) {
+            actions = actions.concat(commands);
+          }
+        });
+
+        Drupal.dreditor.macro.execute(actions);
+        //$("#dreditor-triage-list").empty();
+        return false;
+      });
+      $dtl.appendTo( $ul);
+      var $dd = $(this).next();
+      // Check for a DD with text before a nested DL
+      if ($dd.get().length > 0 && $dd.get()[0].tagName === 'DD') {
+        var text = $dd.html();
+        // Grab all text before an optional DL
+        if ($dd.children('dl').length) {
+          // TODO: why use html()
+          text = text.split(/<dl/).shift();
+        }
+        // Cleanup <p> and </p>
+        text = text.replace(/<p\>/g, "\n").replace(/<\/p\>/g, '');
+        // Cleanup pre and post white spaces
+        text = text.replace(/^\s*/m, '').replace(/\s*$/m, '');
+
+        if (text.length>0) {
+          $action.data('triage-commands').push('@comment(' + text + ')');
+        }
+
+        // Follow a potential DL subtree
+        $dd.find('dl:first').each(function(){
+          var $dl = $(this);
+          Drupal.dreditor.triage.parseDefinitionList($dtl, $dl, level+1);
+        });
+      }
+    });
+  }
+};

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -287,6 +287,9 @@ Drupal.dreditor.triage = {
             .attr('href', src = sources[source].url)
             .attr('title', 'View the ' + label + ' set of templates and macros.')
             .attr('target', '_blank')
+            .click(function(){
+               window.open($(this).attr('href'));
+            })
             .appendTo($linkT)
           ;
           $('<span> or </span>').appendTo($linkT);
@@ -296,6 +299,9 @@ Drupal.dreditor.triage = {
             .attr('href', src = sources[source].url + '/edit')
             .attr('title', 'Edit the ' + label + ' set of templates and macros.')
             .attr('target', '_blank')
+            .click(function(){
+              window.open($(this).attr('href'));
+            })
             .appendTo($linkT)
           ;
         };

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -1,6 +1,3 @@
-Drupal = Drupal || {};
-Drupal.dreditor = Drupal.dreditor || {};
-
 //    //    // Prepend commit message button to comment form.
 //    // @todo Generalize this setup. Somehow.
 //    if (!$container.length) {

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -231,7 +231,7 @@ Drupal.dreditor.triage = {
    */
   tabs : function(sources) {
     // Get the current project title to decide to show its stock responses.
-    var currentProject = Drupal.dreditor.macro.getCurrent('project_title');
+    var currentProject = Drupal.dreditor.issue.getCurrent('project_title');
     var $ul = $('<ul>').addClass('dreditor-triage-full-list');
     $ul.appendTo('#dreditor-triage-list');
 

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -34,18 +34,6 @@
  */
 Drupal.dreditor.triage = {
   /**
-   * We need some CSS injected into the current page
-   *
-   * Colors are based on bluecheese http://groups.drupal.org/node/56698 colors
-   * - Dark blue  : #0678be
-   * - Light blue : #53b0eb
-   * - White      : #eee?
-   */
-  injectCSS : function() {
-    window.alert('css not injected');
-    $('head').append();
-  },
-  /**
    * Getter for hideIrrelevant
    */
   getHideIrrelevant : function() {

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -145,7 +145,8 @@ Drupal.dreditor.triage = {
     $li = $('<li>');
     $li.appendTo($ul);
     var $action = $('<a>')
-      .attr('href', '#').text('Reset')
+      .attr('href', '#')
+      .text('Clear triage cache.')
       .appendTo($li)
       .click(function() {
         Drupal.cache.clear('triage');
@@ -181,7 +182,8 @@ Drupal.dreditor.triage = {
     $li = $('<li>');
     $li.appendTo($ul);
     $action = $('<a>')
-      .attr('href', '#').text('Set custom source')
+      .attr('href', '#')
+      .text('Set custom source')
       .appendTo($li)
       .click(function() {
         var custom = window.prompt('Give the URL of your custom DL tree.' +

--- a/src/js/plugins/triage.js
+++ b/src/js/plugins/triage.js
@@ -1,3 +1,6 @@
+Drupal = Drupal || {};
+Drupal.dreditor = Drupal.dreditor || {};
+
 //    //    // Prepend commit message button to comment form.
 //    // @todo Generalize this setup. Somehow.
 //    if (!$container.length) {
@@ -59,7 +62,7 @@ Drupal.dreditor.triage = {
    *
    * This is usefull when having a lot of issue state change options.
    * Not all options are relavant with respect to the current state.
-   * 
+   *
    * @param {type} toggle
    * @returns {any|Boolean|Drupal.dreditor.triage.getHideIrrelevant.current|Drupal.dreditor.triage.hideIrrelevant.current}
    */
@@ -210,7 +213,7 @@ Drupal.dreditor.triage = {
    * Add the tabs for different triage sources / nodes
    *
    * All except the custom node are supposed to come from the triage root nodes
-   * 
+   *
    * @param {type} sources
    * @returns {undefined}
    */

--- a/src/less/tabs.less
+++ b/src/less/tabs.less
@@ -1,0 +1,61 @@
+.dreditor-tabs-container {
+  padding-right: 5px;
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+.dreditor-tabs {
+  text-align: right;
+}
+.dreditor-tabs .dreditor-tab {
+  display: inline;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+  margin-left: 4px;
+  margin-top: 3px;
+  color: black;
+  padding: 2px 10px;
+}
+.dreditor-tabs.active .dreditor-tab {
+  border-bottom-left-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+.dreditor-tabs.active > .dreditor-tab.active {
+  /* .dark-blue-50 */
+  background-color: #dcdcdc;
+}
+.dreditor-tabs.odd > .dreditor-tab.active {
+  /* .dark-blue-40 */
+  background-color: #bdbdbd;
+}
+.dreditor-tabs > .dreditor-tab {
+  /* .dark-blue-30 */
+  background-color: #828282;
+}
+.dreditor-tabs .dreditor-tab.active:hover ,
+.dreditor-tabs .dreditor-tab:hover ,
+.dreditor-tabs .dreditor-tab.odd:hover {
+  /* .dark-blue */
+  background-color: #0678be;
+}
+.dreditor-tab a:link,
+.dreditor-tab a:visited,
+.dreditor-tab a:active {
+  text-decoration: none;
+  color: black;
+}
+.dreditor-tab-content {
+  clear:both;
+  display: none;
+  padding: 3px;
+  /* .dark-blue-50 */
+  background-color: #dcdcdc;
+}
+.dreditor-tab-content.odd {
+  /* .dark-blue-40 */
+  background-color: #bdbdbd;
+}
+.dreditor-tab-content.active {
+  display: block;
+}

--- a/src/less/triage.less
+++ b/src/less/triage.less
@@ -1,0 +1,81 @@
+#dreditor-triage {
+  margin: 2px;
+  width: 95%;
+}
+.triage-in-context {
+  font-weight: bolder;
+}
+.triage-hide-irrelevant .triage-not-in-context {
+  display:none;
+}
+#dreditor-triage ul {
+  overflow: visible;
+}
+#dreditor-triage-list {
+  margin: 0;
+  z-index: 10;
+  font-size: 1.2em;
+}
+#dreditor-triage-list ul {
+  margin: 0;
+  padding: 0;
+  background-color: #53b0eb;
+  width: 130px;
+}
+#dreditor-triage-list li {
+  background-color: white;
+  border: 1px solid black;
+}
+#dreditor-triage-list li {
+  border-top: none;
+}
+#dreditor-triage-list li:first-child {
+  border-top: 1px solid black;
+}
+#dreditor-triage-list ul > a {
+  width: auto;
+}
+#dreditor-triage-list li {
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+#dreditor-triage-list ul ul li {
+  margin: 0;
+}
+#dreditor-triage-list ul ul {
+  position: absolute;
+  top: -1px;
+  left: 128px;
+}
+#dreditor-triage-list li > ul {
+  display:none;
+}
+#dreditor-triage-list li:hover > ul {
+  display: block;
+}
+#dreditor-triage-list li a {
+  display: block;
+  padding: 0.25em;
+  text-decoration: none;
+  color: black;
+}
+#dreditor-triage-list li.source {
+  text-align: right;
+  font-size: smaller;
+  background-color: #EEE;
+  border-top:1px dashed;
+}
+#dreditor-triage-list li.source a {
+  display: inline;
+}
+#dreditor-triage-list lli:hover {
+  background-color: #28D;
+}
+#dreditor-triage-list li:hover > a {
+  background-color: #0678be;
+}
+#dreditor-triage-list li.collapsed {
+  background-color: #53b0eb;
+}

--- a/tests/src/js/extensions/tabs.html
+++ b/tests/src/js/extensions/tabs.html
@@ -7,7 +7,11 @@
     <script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>
     <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.12.0.css" type="text/css" media="screen">
 
-    <script>Drupal = {};</script>
+    <script>
+      Drupal = {};
+      Drupal.dreditor = {};
+    </script>
+
     <script src='../../../../src/js/extensions/tabs.js'></script>
 
     <script>

--- a/tests/src/js/extensions/tabs.html
+++ b/tests/src/js/extensions/tabs.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>dreditor tabs test page</title>
+    <script src="http://code.jquery.com/jquery-1.4.4.min.js"></script>
+
+    <script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.12.0.css" type="text/css" media="screen">
+
+    <script>Drupal = {};</script>
+    <script src='../../../../src/js/extensions/tabs.js'></script>
+
+    <script>
+      (function ($) {
+        $(document).ready(function() {
+          var tabs = Drupal.dreditor.ux.tabs;
+          var $container = $('#dreditor-tabs-container-test');
+          tabs.createTabContainer($container);
+          tabs.addTab($container, 'Test tab 1', 'id-1', $('<p>').text('Content of tab 1'));
+          tabs.addTab($container, 'Test tab 2', 'id-2', $('<p>').text('Content of tab 2'));
+          tabs.addTab($container, 'Test tab 3', 'id-3', $('<p>').text('Replaced by sub tabs'));
+
+          var $container = $('.dreditor-tab-content.id-3');
+          tabs.createTabContainer($container);
+          tabs.addTab($container, 'Test sub tab 1', 'id-4', $('<p>').text('Content of sub tab 1'));
+          tabs.addTab($container, 'Test sub tab 2', 'id-5', $('<p>').text('Content of sub tab 2'));
+          tabs.addTab($container, 'Test sub tab 3', 'id-6', $('<p>').text('Content of sub tab 3'));
+          var $container = $('.dreditor-tab-content.id-6');
+          tabs.createTabContainer($container);
+          tabs.addTab($container, 'Test sub sub tab 1', 'id-7', $('<p>').text('Toggle color scheme depending on tab depth.'));
+          var $container = $('.dreditor-tab-content.id-2 > p');
+
+          // We are done adding tabs ... now initialise the odd/even
+          tabs.init();
+          tabs.bind();
+        });
+      })(jQuery);
+      
+    </script>
+
+    <link rel="stylesheet" type="text/css" href="../../../../build/dreditor.css" />
+    <style>
+      div#dreditor-comment-container {
+        width: 900px;
+        border: 2px dashed red;
+        clear: both;
+      }
+    </style>
+
+    <style>
+      .dreditor-triage-root {
+        position: relative;
+        height: 150px;
+      }
+      .dreditor-triage-root ul {
+        top: 0px;
+        left: 0px;
+        width: 120px;
+        border: 1px solid red;
+      }
+      .dreditor-triage-root li {
+        
+      }
+
+      .dreditor-triage-root ul ul {
+        left: 120px;
+      }
+      .dreditor-triage-root > ul ul li {
+        display: none;
+        border: 1px dashed green;
+      }
+      .dreditor-triage-root ul li:hover > ul > li ,
+      .dreditor-triage-root ul li:focus > ul > li {
+        display: block;
+      }
+    </style>
+
+
+  </head>
+  <body>
+    <p>
+      What's on this page? This page is about
+      <a href="http://drupal.org/node/1345614">Merging dreditor toggle buttons</a>
+      for making a better UX for <a href="http://drupal.org/node/1115636">Macros &amp; Templates</a>
+    </p>
+    <ul>
+      <li>First there is a test tab strip with a sub tab under #3</li>
+      <li>You can 'close' a tab by clicking it again. This is to preserve space.</li>
+      <li>Things to solve are:
+        <ul>
+          <li>Styling concerning borders around tabs, around tab content, closing all tabs</li>
+          <li>Is closing a tab good UX?</li>
+          <li>?</li>
+        </ul>
+      </li>
+    </ul>
+
+    <div style="width: 400px;">
+      The next tabs container is filled by code.
+      <div id="dreditor-tabs-container-test">This dreditor-tabs-container is initial empty</div>
+      This is after the container.
+    </div>
+
+    <div style="clear:both">&nbsp</div>
+    <div>
+      <p>Intended mockup of <a href="http://drupal.org/node/1345614">dreditor comment tabs</a>
+      </p>
+      <img src="http://drupal.org/files/replies.png" />
+    </div>
+  </body>
+</html>

--- a/tests/src/js/extensions/tabs.html
+++ b/tests/src/js/extensions/tabs.html
@@ -13,9 +13,10 @@
     </script>
 
     <script src='../../../../src/js/extensions/tabs.js'></script>
+    <link rel="stylesheet" type="text/css" href="../../../../build/dreditor.css" />
 
     <script>
-      (function ($) {
+      (function($) {
         $(document).ready(function() {
           var tabs = Drupal.dreditor.ux.tabs;
           var $container = $('#dreditor-tabs-container-test');
@@ -39,49 +40,29 @@
           tabs.bind();
         });
       })(jQuery);
-      
+
     </script>
 
-    <link rel="stylesheet" type="text/css" href="../../../../build/dreditor.css" />
-    <style>
-      div#dreditor-comment-container {
-        width: 900px;
-        border: 2px dashed red;
-        clear: both;
-      }
-    </style>
+    <script>
+      module("Tabs support");
 
-    <style>
-      .dreditor-triage-root {
-        position: relative;
-        height: 150px;
-      }
-      .dreditor-triage-root ul {
-        top: 0px;
-        left: 0px;
-        width: 120px;
-        border: 1px solid red;
-      }
-      .dreditor-triage-root li {
-        
-      }
-
-      .dreditor-triage-root ul ul {
-        left: 120px;
-      }
-      .dreditor-triage-root > ul ul li {
-        display: none;
-        border: 1px dashed green;
-      }
-      .dreditor-triage-root ul li:hover > ul > li ,
-      .dreditor-triage-root ul li:focus > ul > li {
-        display: block;
-      }
-    </style>
-
-
+      test("Toggle tabs", function() {
+        // TODO: http://qunitjs.com/cookbook/#testing-user-actions
+        ok("true", "We fake success as we need to write decent tests first.");
+        // TODO: Write tests
+        //   click on id-1 then validate 'Content of tab 1' is visible
+        //   click on id-1 then validate 'Content of tab 1' is not visible
+      });
+    </script>
   </head>
   <body>
+    <div id="qunit"></div> <!-- QUnit fills this with results, etc -->
+    <div id='qunit-fixture'>
+
+      <!-- any HTML you want to be present in each test (will be reset for each test) -->
+
+    </div>
+
     <p>
       What's on this page? This page is about
       <a href="http://drupal.org/node/1345614">Merging dreditor toggle buttons</a>


### PR DESCRIPTION
This is a first stab to restart [Issue Macros and Templates](https://drupal.org/node/1115636)

As this is a WIP please give it a try.
## Testing
1. Navigate to any Drupal core issue : https://drupal.org/node/2160555
2. You should see ![node-view-comment-form](https://cloud.githubusercontent.com/assets/371014/3208572/62117f02-ee3c-11e3-8379-be7169a8c623.png)
3. Click on `Macro & Templates`
   1. Click on `Drupal Core`
   2. Select Macro & Templates > Drupal code > Gates > Documentation
   3. Select 'Gates' ![drupal-gates](https://cloud.githubusercontent.com/assets/371014/3208598/cc2c6aaa-ee3c-11e3-9131-f702c0ec4e29.png)
   4. Hover over `Add issue summary` and note it is about to set `Status` and `Tags` 
   5. Click on `Add issue summary`
   6. Check for status change and tags
4. Click on `Macro & Templates`
   1. Click on `_default`
   2. Click on last item 'view' or 'edit' to check or edit the stock responses.
## Open issues
- [x] Fix 'view' or 'edit'
- [x] It adds itself through commit.message.js which already has a generalize #todo
- [x] Remove old links
- [x] Add to node/*/edit page
- [x] As node/*/edit has the issue _fields_ state changingmacro's are broken.
