### PR TITLE
Refactor 80-character ruler for speed

### DIFF
--- a/src/js/plugins/patch.review.js
+++ b/src/js/plugins/patch.review.js
@@ -419,6 +419,7 @@ Drupal.dreditor.patchReview.behaviors.setup = function (context, code) {
 
   // Setup code container.
   var $code = $('<table id="code"></table>');
+  $code.append('<thead><tr><th class="line-ruler" colspan="3"></th></tr></thead>');
   var $menu = $('#menu', context);
   var $lastFile = $('<li>Parse error</li>');
 
@@ -553,39 +554,30 @@ Drupal.dreditor.patchReview.behaviors.setup = function (context, code) {
   //
   // We also calculate the width of the gutter (line numbers) by using the
   // largest combination of line numbers calculated above.
-  var $lineRuler = $('<table id="code"><tbody><tr><td class="ln ln-1" data-line-number="' + maxln1 + '"></td><td class="ln ln-2" data-line-number="' + maxln2 + '"></td><td><span class="pre">' + new Array(82).join('0') + '</span></td></tr></tbody></table>')
+  var $lineRuler = $('<table id="code"><thead><tr><th class="line-ruler" colspan="3"></th></tr></thead><tbody><tr><td class="ln ln-1" data-line-number="' + maxln1 + '"></td><td class="ln ln-2" data-line-number="' + maxln2 + '"></td><td><span class="pre">' + new Array(82).join('0') + '</span></td></tr></tbody></table>')
     .appendTo('#dreditor');
   var ln1gutter = $lineRuler.find('.ln-1').outerWidth();
   var ln2gutter = $lineRuler.find('.ln-2').outerWidth();
   var lineWidth = $lineRuler.find('.pre').width();
   // Add 10px for padding (the td that contains span.pre).
   var lineRulerOffset = ln1gutter + ln2gutter + lineWidth + 10;
-  var lineRulerStyle = '';
+  var lineRulerStyle = {};
   // Check for a reasonable value for the ruler offset.
   if (lineRulerOffset > 100) {
-    lineRulerStyle = '#dreditor #code tbody:after { visibility: visible; left: ' + lineRulerOffset + 'px; }';
+    lineRulerStyle = {
+      'visibility': 'visible',
+      'left': lineRulerOffset + 'px'
+    };
   }
   $lineRuler.remove();
-
-  // Add a style tag containing the CSS for the line ruler.
-  var styleEl = document.createElement("style");
-  document.getElementsByTagName("head")[0].appendChild(styleEl);
-  if (styleEl.styleSheet) {
-    if (!styleEl.styleSheet.disabled) {
-      styleEl.styleSheet.cssText = lineRulerStyle;
-    }
-  } else {
-    try {
-      styleEl.innerHTML = lineRulerStyle;
-    } catch(e) {
-      styleEl.innerText = lineRulerStyle;
-    }
-  }
 
   // Append to body...
   $('#dreditor-content', context)
     // the parsed code.
     .append($code);
+
+  // Set the position of the 80-character ruler.
+  $('thead .line-ruler').css(lineRulerStyle);
 
   // Append diffstat to sidebar.
   $diffstat.html(diffstat.files + '&nbsp;files changed, ' + diffstat.insertions + '&nbsp;insertions, ' + diffstat.deletions + '&nbsp;deletions.');

--- a/src/less/dreditor.less
+++ b/src/less/dreditor.less
@@ -149,15 +149,14 @@
   background: transparent;
   position: relative;
 }
-#dreditor #code tbody:after {
-  content: "";
+#dreditor #code thead .line-ruler {
   background: #ccc;
   background: rgba(0,0,0,0.15);
   position: absolute;
   height: 100%;
   width: 1px;
-  display: block;
   top: 0;
+  padding: 0;
   visibility: hidden;
 }
 #dreditor #code .pre span.space {

--- a/src/less/dreditor.less
+++ b/src/less/dreditor.less
@@ -149,19 +149,16 @@
   background: transparent;
   position: relative;
 }
-#dreditor #code .pre .line-ruler {
+#dreditor #code tbody:after {
+  content: "";
   background: #ccc;
   background: rgba(0,0,0,0.15);
   position: absolute;
-  bottom: -4px;
-  top: -4px;
+  height: 100%;
   width: 1px;
+  display: block;
+  top: 0;
   visibility: hidden;
-  z-index: 1;
-}
-#dreditor #code tr:hover .pre .line-ruler {
-  background-color: #E8DAB3;
-  background-color: rgba(154, 124, 41, 0.3);
 }
 #dreditor #code .pre span.space {
   display: inline-block;
@@ -209,10 +206,6 @@
   background-color: #f7c8c8;
   border-color: #e9aeae;
 }
-#dreditor #code tr.old .line-ruler {
-  background-color: #B53B3B;
-  background-color: rgba(181, 59, 59, 0.2);
-}
 #dreditor #code tr.new {
   background-color: #dfd;
   color: #008503;
@@ -226,10 +219,6 @@
 #dreditor #code tr.new .ln {
   background-color: #ceffce;
   border-color: #b4e2b4;
-}
-#dreditor #code tr.new .line-ruler {
-  background-color: #167A00;
-  background-color: rgba(22, 122, 0, 0.2);
 }
 #dreditor #code .comment {
   color: #070;


### PR DESCRIPTION
> Don't create a div for each line. Instead, calculate the width of the
> gutter (line numbers) and take the padding of the "code" cell into
> account. This approach results in vastly improved performance when
> reviewing large patches, positions the ruler at the same pixel
> position as before, and barely changes the visual appearance.

I mostly used https://drupal.org/comment/7293984#comment-7293984 to test as an example of a large patch that without this refactor is extremely sluggish when scrolling.

So far this has only been tested in Chrome.
