### PR TITLE
Restored GreaseMonkey user script header to simplify development.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,21 @@ module.exports = function(grunt) {
   grunt.initConfig({
     // Metadata.
     pkg: grunt.file.readJSON('package.json'),
-    banner: '/**\n' +
+    banner: '// ==UserScript==' + '\n' +
+      '// @name           <%= pkg.title || pkg.name %>' + '\n' +
+      '// @namespace      http://dreditor.org' + '\n' +
+      '// @description    <%= pkg.description %>' + '\n' +
+      '// @icon           https://drupal.org/misc/druplicon.png' + '\n' +
+      '// @version        <%= pkg.version %>' + '\n' +
+      '// @grant          none' + '\n' +
+      '// @include        *://dreditor.org/*' + '\n' +
+      '// @include        *://*.dreditor.org/*' + '\n' +
+      '// @include        *://drupal.org/*' + '\n' +
+      '// @include        *://*.drupal.org/*' + '\n' +
+      '// @include        *://devdrupal.org/*' + '\n' +
+      '// @include        *://*.devdrupal.org/*' + '\n' +
+      '// ==/UserScript==' + '\n\n' +
+      '/**\n' +
       ' * <%= pkg.title || pkg.name %> <%= pkg.version %>\n' +
       '<%= pkg.homepage ? " * " + pkg.homepage + "\\n" : "" %>' +
       ' * <%= pkg.description %>\n' +


### PR DESCRIPTION
By restoring the GreaseMonkey user script header, the built `dreditor.js` script can be imported and used as-is in Firefox with the correct grants and domain settings - and only _once_.

Simply running `grunt watch` updates the script and Firefox automatically loads the new script by simply reloading a drupal.org page in the browser (a simple reload is sufficient, a hard refresh is not required).

This drastically simplifies the development experience for me (and possibly everyone else who's developing on Firefox), so it would be great if we could add it to the mainline.
