### PR TITLE
Added task/target 'dev' to speed up rebuild via 'grunt watch:dev' for live debugging.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -206,6 +206,15 @@ module.exports = function(grunt) {
           '<%= qunit.all %>'
         ],
         tasks: ['default']
+      },
+      dev: {
+        files: [
+          '<%= jshint.package.src %>',
+          '<%= jshint.gruntfile.src %>',
+          '<%= jshint.js.src %>',
+          'src/less/**/*.less'
+        ],
+        tasks: ['dev']
       }
     },
     release: {
@@ -268,6 +277,7 @@ module.exports = function(grunt) {
 
   // Default tasks.
   grunt.registerTask('default', ['clean', 'less', 'css2js', 'jshint', 'qunit', 'concat', 'uglify', 'copy', 'sed']);
+  grunt.registerTask('dev', ['less', 'css2js', 'concat']);
 
   // Build extensions.
   grunt.registerTask('build:chrome', ['compress:chrome']);


### PR DESCRIPTION
When having to debug and adjust for drupal.org UI changes, `dreditor.js` should rebuild as quickly as possible.  As I'm developing on Windows, any unnecessary file operation slows down the `grunt watch` process in substantial ways.

This PR introduces a new grunt task/target `dev`, which only rebuilds/recompiles the `dreditor.js` script itself, so that Firefox/GreaseMonkey can consume it immediately.
