### PR TITLE
Fixed 80 chars marker does not appear in Firefox on Windows.

### DIFF
--- a/src/less/dreditor.less
+++ b/src/less/dreditor.less
@@ -150,8 +150,7 @@
   position: relative;
 }
 #dreditor #code thead .line-ruler {
-  background: #ccc;
-  background: rgba(0,0,0,0.15);
+  border-left: 1px solid rgba(0,0,0,0.15);
   position: absolute;
   height: 100%;
   width: 1px;


### PR DESCRIPTION
The 80-chars marker does not appear in Firefox.  I tried several adjustments for z-index, height, position, etc.pp but no luck.

But luckily, it works with `border-left`, which achieves the exact same thing.

I also skipped/dropped the rgb-without-alpha color, since we can rely on modern browsers.
