### PR TITLE
Fixed placement/position of image embed buttons.

### DIFF
--- a/src/js/plugins/inline.image.js
+++ b/src/js/plugins/inline.image.js
@@ -5,7 +5,8 @@ Drupal.behaviors.dreditorInlineImage = {
   attach: function (context) {
     var $context = $(context);
     var $comment = $(':input[name="nodechanges_comment_body[value]"]');
-    $context.find('.file > a').once('dreditor-inlineimage', function () {
+    var $elements = $context.find('.file').once('dreditor-inlineimage');
+    $elements.find('> a').each(function () {
       var $link = $(this);
       var url = $link.attr('href');
       // Only process image attachments.
@@ -15,7 +16,7 @@ Drupal.behaviors.dreditorInlineImage = {
       // Generate inline image button (cannot be <a>, other scripts bind links).
       var $button = $('<span class="dreditor-button dreditor-inlineimage">Embed</span>');
       // Append inline image button to attachment.
-      $link.parent().parent().append($button);
+      $link.parent().prepend($button);
       // Override click event.
       $button
         .bind('click', function (e) {

--- a/src/less/dreditor.less
+++ b/src/less/dreditor.less
@@ -72,7 +72,7 @@
 .dreditor-button {
   margin: 0 0.5em 0.5em;
 }
-.dreditor-patchreview, .dreditor-patchtest {
+.dreditor-patchreview, .dreditor-patchtest, .dreditor-inlineimage {
   float: right;
   line-height: 1.25em;
   margin: 0 0 0 1em;


### PR DESCRIPTION
The "Embed" button currently appears below an attached file.  For consistency, it should be placed/positioned in the exact same way as the patch review/simplytest.me buttons for patch files.

While being there, also fixing the selector + .once() filtering in the same way as in #98, since the behavior is needlessly iterating over links that have been injected by Dreditor. — I'm fairly sure that this is actually the proper fix for the recently committed adjustment that changed the link into a span, but not changing/reverting that here, since a span works, too.
