### PR TITLE
Tooltip of syntax autocomplete suggestion does not appear.

### DIFF
--- a/src/js/plugins/syntax.autocomplete.js
+++ b/src/js/plugins/syntax.autocomplete.js
@@ -21,6 +21,7 @@ Drupal.dreditor.syntaxAutocomplete = function (element) {
 
   this.$suggestion = $('<span></span>');
   this.$tooltip = $('<div class="dreditor-tooltip">TAB: </div>')
+    .hide()
     .insertAfter(this.$element)
     .append(this.$suggestion);
 
@@ -135,7 +136,7 @@ Drupal.dreditor.syntaxAutocomplete.prototype.setSuggestion = function (suggestio
   if (suggestion !== self.suggestion) {
     self.suggestion = suggestion;
     self.$suggestion.text(self.suggestion.replace('^', ''));
-    self.$tooltip.css({ display: 'inline-block' });
+    self.$tooltip.show();
   }
 };
 

--- a/src/less/dreditor.less
+++ b/src/less/dreditor.less
@@ -362,6 +362,7 @@ div.dreditor-issuecount {
   font-family: sans-serif;
   font-size: 11px;
   line-height: 150%;
+  z-index: 100;
 }
 // D.o temporary "fixes".
 .field-name-field-issue-files table, .field-name-field-issue-changes table.nodechanges-file-changes {


### PR DESCRIPTION
The changed HTML of d.o (possibly since D7 upgrade even, dunno) uses `z-index` on its own, which causes the autocomplete suggestion tooltip to not appear.

While being there, I also simplified the tooltip visibility toggling.
