### PR TITLE
Added jshint:dev (limited to actual JS files) to grunt dev task/target.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -277,7 +277,7 @@ module.exports = function(grunt) {
 
   // Default tasks.
   grunt.registerTask('default', ['clean', 'less', 'css2js', 'jshint', 'qunit', 'concat', 'uglify', 'copy', 'sed']);
-  grunt.registerTask('dev', ['less', 'css2js', 'concat']);
+  grunt.registerTask('dev', ['less', 'css2js', 'jshint:js', 'concat']);
 
   // Build extensions.
   grunt.registerTask('build:chrome', ['compress:chrome']);


### PR DESCRIPTION
Follow-up to #100:

When limiting jshint to the actual JS files of Dreditor (skipping package/Gruntfile), then the additional delay of jshint is actually still acceptable for the new `dev` task.
