### PR TITLE
Follow-up to #105: Replace comment permalinks with legacy comment permalinks.

### DIFF
--- a/src/js/plugins/comment.permalinks.js
+++ b/src/js/plugins/comment.permalinks.js
@@ -3,14 +3,10 @@
  */
 Drupal.behaviors.dreditorCommentPermalinks = {
   attach: function (context) {
+    var path = window.location.pathname;
     $(context).find('.comment > .permalink').once('dreditor-permalinks', function () {
-      var $container = $('<div class="dreditor-permalinks"></div>').insertBefore(this);
-      var classAttr = ' class="permalink dreditor-permalinks-processed"';
-      var path = window.location.pathname;
-      var comment = /\d+$/.exec(this.text);
-
       // Pre-D7 issue#comment URL, suitable for IRC/Druplicon.
-      $container.append('<a rel="irc" href="' + path + this.hash + '"' + classAttr + '>#' + comment + '</a>');
+      this.href = path + this.hash;
 
       // Issue filter link macro.
       // @todo Href produces a URL. HTML5 Clipboard API does not allow to copy
@@ -18,7 +14,7 @@ Drupal.behaviors.dreditorCommentPermalinks = {
       // @see http://caniuse.com/#feat=clipboard
       // @see http://www.w3.org/TR/clipboard-apis/
 //      if (window.ClipBoardEvent) {
-//        var macro = '[#' + /\d+$/.exec(window.location.pathname) + '-' + comment + ']';
+//        var macro = '[#' + /\d+$/.exec(path) + '-' + comment + ']';
 //        var $link = $('<a rel="filter" href="' + macro + '"' + classAttr + '>' + macro + '</a>');
 //        $link.click(function (e) {
 //          e.preventDefault();


### PR DESCRIPTION
I disagree with this on technical/architectural merits of Drupal core, but meh. ;-)
