### PR TITLE
Remove https://drupal.org from image url.

### DIFF
--- a/src/js/plugins/inline.image.js
+++ b/src/js/plugins/inline.image.js
@@ -24,6 +24,8 @@ Drupal.behaviors.dreditorInlineImage = {
           $('html, body').animate({
             scrollTop: $comment.offset().top
           }, 300);
+          // Remove protocol + drupal.org
+          url = url.replace(/^https\:\/\/drupal\.org/, '');
           // Insert image tag to URL in comment textarea.
           $comment.focus().val($comment.val() + "\n<img src=\"" + url + "\" alt=\"\" />\n");
           e.preventDefault();


### PR DESCRIPTION
Clicking the embed button adds the full url to the image render it invalid now and then.

My fix removes http://drupal.org from the image url changing it from `<img src="https://drupal.org/files/issues/Maintenance%20View.png" alt="" />` to `<img src="/files/issues/Maintenance%20View.png" alt="" />`
