### PR TITLE
Fixed Firefox autoload fails to find .xpi file.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -295,10 +295,15 @@ module.exports = function(grunt) {
   grunt.registerTask('build:firefox', ['mozilla-cfx-xpi', 'autoload:ff']);
   grunt.registerTask('build:safari', 'Builds the safari extension', function () {
     grunt.util.spawn({
-      cmd:'build-safari-ext',
-      args:[grunt.template.process('<%= pkg.name %>-<%= pkg.version %>'), grunt.template.process(process.cwd() + '/build/<%= pkg.name %>.safariextension'), process.cwd() + '/release'],
-      fallback:-255
-    }, function (error, result, code) {
+      cmd: 'build-safari-ext',
+      args: [
+        grunt.template.process('<%= pkg.name %>-<%= pkg.version %>'),
+        grunt.template.process(process.cwd() + '/build/<%= pkg.name %>.safariextension'),
+        process.cwd() + '/release'
+      ],
+      fallback: -255
+    },
+    function (error, result, code) {
       if (0 !== code) {
         grunt.log.errorlns(result.stdout);
         grunt.log.errorlns(result.stderr);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -239,8 +239,7 @@ module.exports = function(grunt) {
         options: {
           "mozilla-addon-sdk": "master",
           extension_dir: "build/firefox",
-          dist_dir: "release",
-          arguments: "--output-file=<%= pkg.name %>-<%= pkg.version %>.xpi"
+          dist_dir: "release"
         }
       }
     },
@@ -272,20 +271,21 @@ module.exports = function(grunt) {
 
   // Autoload Firefox extension.
   // @see https://addons.mozilla.org/en-US/firefox/addon/autoinstaller/
-  grunt.registerTask('autoload:ff', "Autoload new XPI extension in Firefox", function() {
+  grunt.registerTask('autoload:ff', "Autoload new XPI extension in Firefox", function () {
     var done = this.async();
     grunt.util.spawn({
       cmd: 'wget',
       args: [
-        '--post-file=release/' + grunt.template.process('<%= pkg.name %>-<%= pkg.version %>.xpi'),
+        '--post-file=release/' + grunt.template.process('<%= pkg.name %>.xpi'),
         'http://localhost:8888'
       ],
-      opts: grunt.option('debug') ? {stdio: 'inherit'} : {}
-    }, function (error, result, code) {
+      opts: grunt.option('debug') ? { stdio: 'inherit' } : {}
+    },
+    function (error, result, code) {
       if(code !== 8) {
         return grunt.warn('Auto-loading Firefox extension failed: (' + code + ') ' + error);
       }
-      grunt.log.ok('Auto-loaded "' + grunt.template.process('<%= pkg.name %>-<%= pkg.version %>.xpi') + '" into Firefox...');
+      grunt.log.ok('Auto-loaded "' + grunt.template.process('<%= pkg.name %>.xpi') + '" into Firefox.');
       done();
     });
   });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -217,7 +217,7 @@ module.exports = function(grunt) {
     compress: {
       chrome: {
         options: {
-          archive: 'release/chrome-<%= pkg.version %>.zip',
+          archive: 'release/chrome/<%= pkg.name %>.zip',
           mode: 'zip'
         },
         expand: true,
@@ -239,7 +239,10 @@ module.exports = function(grunt) {
         options: {
           "mozilla-addon-sdk": "master",
           extension_dir: "build/firefox",
-          dist_dir: "release"
+          dist_dir: "release/firefox",
+          // --output-file is an experimental option, not guaranteed to exist.
+          // @see https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/cfx#Experimental_Options_3
+          arguments: "--output-file=<%= pkg.name %>.xpi"
         }
       }
     },
@@ -273,19 +276,22 @@ module.exports = function(grunt) {
   // @see https://addons.mozilla.org/en-US/firefox/addon/autoinstaller/
   grunt.registerTask('autoload:ff', "Autoload new XPI extension in Firefox", function () {
     var done = this.async();
+    var xpi = 'release/firefox/' + grunt.template.process('<%= pkg.name %>.xpi');
     grunt.util.spawn({
       cmd: 'wget',
       args: [
-        '--post-file=release/' + grunt.template.process('<%= pkg.name %>.xpi'),
+        '--post-file=' + xpi,
         'http://localhost:8888'
       ],
-      opts: grunt.option('debug') ? { stdio: 'inherit' } : {}
+      opts: !grunt.option('debug') ? {} : {
+        stdio: 'inherit'
+      }
     },
     function (error, result, code) {
-      if(code !== 8) {
-        return grunt.warn('Auto-loading Firefox extension failed: (' + code + ') ' + error);
+      if (code !== 8) {
+        return grunt.warn('Auto-loading ' + xpi + ' failed: (' + code + ') ' + error);
       }
-      grunt.log.ok('Auto-loaded "' + grunt.template.process('<%= pkg.name %>.xpi') + '" into Firefox.');
+      grunt.log.ok('Auto-loaded ' + xpi + ' into Firefox.');
       done();
     });
   });
@@ -297,9 +303,9 @@ module.exports = function(grunt) {
     grunt.util.spawn({
       cmd: 'build-safari-ext',
       args: [
-        grunt.template.process('<%= pkg.name %>-<%= pkg.version %>'),
+        grunt.template.process('<%= pkg.name %>'),
         grunt.template.process(process.cwd() + '/build/<%= pkg.name %>.safariextension'),
-        process.cwd() + '/release'
+        process.cwd() + '/release/safari'
       ],
       fallback: -255
     },


### PR DESCRIPTION
Removes the version suffix from the build to always build just "dreditor.xpi".  Adding a version suffix is the responsibility of a build/release archiver post-process.
