### PR TITLE
Updated issue comment form backup for d.o D7 upgrade.

### DIFF
--- a/src/js/plugins/form.backup.js
+++ b/src/js/plugins/form.backup.js
@@ -9,7 +9,7 @@
  */
 Drupal.behaviors.dreditorFormBackup = {
   attach: function (context) {
-    $(context).find('#comment-form:has(#edit-category)').once('dreditor-form-backup', function () {
+    $(context).find('#project-issue-node-form').once('dreditor-form-backup', function () {
       var $form = $(this);
 
       var $restore = $('<a href="javascript:void()" class="dreditor-application-toggle">Restore previously entered data</a>').click(function () {


### PR DESCRIPTION
Finally it's back.  Just needed a minimal selector tweak.

As also stated in the existing JSDoc of the file, especially since the D7 upgrade, d.o is (completely) eating some of my comments sometimes - my browser performs a _GET redirect_ to the same page, losing all submitted POST data + even browser history, so not even the browser stores the form values in any way...

Due to that, I even started to restarted the habit of copying my comments before hitting the Save button... This good ol' behavior in Dreditor successfully protects against that weird d.o misbehavior + allows you to restore your last submitted form values from localStorage. :+1: 

Drupal infra is currently working on a CDN and related stuff, so I expect that these terrible incidents will only increase in the future.
