### PR TITLE
Fixed auto-generated documentation in grunt --help.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -277,10 +277,12 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-release');
 
   // Install tasks.
-  grunt.registerTask('install', ['mozilla-addon-sdk']);
+  grunt.registerTask('install', 'Installs dependencies.',
+    ['mozilla-addon-sdk']);
 
   // Default tasks.
-  grunt.registerTask('default', ['clean', 'less', 'css2js', 'jshint', 'concat', 'copy', 'sed']);
+  grunt.registerTask('default', 'Compiles code.',
+    ['clean', 'less', 'css2js', 'jshint', 'concat', 'copy', 'sed']);
 
   // Realtime development tasks.
   // Enjoy: `grunt watch:ff`
@@ -297,8 +299,9 @@ module.exports = function(grunt) {
   // config of the watch task ad-hoc.
   // @see https://github.com/gruntjs/grunt-contrib-watch/issues/71#issuecomment-26152333
   // Firefox.
-  grunt.registerTask('dev:ff',  ['less', 'css2js', 'jshint:js', 'concat', 'copy:firefox', 'sed']);
-  grunt.registerTask('watch:ff', function () {
+  grunt.registerTask('dev:ff', 'Compiles code to build a Firefox extension. (see watch:ff)',
+    ['less', 'css2js', 'jshint:js', 'concat', 'copy:firefox', 'sed']);
+  grunt.registerTask('watch:ff', 'Enables real-time development for Firefox.', function () {
     var config = grunt.config('watch');
     config.tasks = ['dev:ff', 'build:firefox', 'autoload:ff'];
     // Auto-run once upon invocation.
@@ -309,13 +312,19 @@ module.exports = function(grunt) {
   });
 
   // Test tasks.
-  grunt.registerTask('test', ['qunit']);
-  grunt.registerTask('travis-ci', ['default', 'test']);
+  grunt.registerTask('test', 'Runs tests.',
+    ['qunit']);
+  grunt.registerTask('travis-ci', 'Compiles code and runs tests.',
+    ['default', 'test']);
 
   // Build tasks.
-  grunt.registerTask('build:chrome', ['compress:chrome']);
-  grunt.registerTask('build:firefox', ['mozilla-cfx-xpi']);
-  grunt.registerTask('build:safari', 'Builds the safari extension', function () {
+  grunt.registerTask('build', 'Compiles code and builds all extensions.',
+    ['default', 'build:chrome', 'build:firefox', 'build:safari']);
+  grunt.registerTask('build:chrome', 'Builds the Chrome extension.',
+    ['compress:chrome']);
+  grunt.registerTask('build:firefox', 'Builds the Firefox extension.',
+    ['mozilla-cfx-xpi']);
+  grunt.registerTask('build:safari', 'Builds the Safari extension.', function () {
     grunt.util.spawn({
       cmd: 'build-safari-ext',
       args: [
@@ -332,12 +341,11 @@ module.exports = function(grunt) {
       }
     });
   });
-  grunt.registerTask('build', ['default', 'compress:chrome', 'build:firefox', 'build:safari']);
 
   // Autoload tasks.
   // Firefox.
   // @see https://addons.mozilla.org/en-US/firefox/addon/autoinstaller/
-  grunt.registerTask('autoload:ff', "Load XPI extension into Firefox", function () {
+  grunt.registerTask('autoload:ff', 'Loads the XPI extension into Firefox.', function () {
     var done = this.async();
     var xpi = 'release/firefox/' + grunt.template.process('<%= pkg.name %>.xpi');
     grunt.util.spawn({

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -193,7 +193,13 @@ module.exports = function(grunt) {
     },
     watch: {
       files: [
-        // Force-ignore artifacts.
+        // Force-exclude artifacts.
+        // Despite not being included in the list of files, the watch task can
+        // be intermittently interrupted by a build:* task with:
+        // >> File "release" added.
+        // which may even cause an infinite loop. Seemingly a bug in watch;
+        // possibly limited to Windows/NTFS/msys. Exclusions must be defined
+        // first; all arguments are processed/merged sequentially.
         '!build',
         '!build/**',
         '!release',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,7 @@ module.exports = function(grunt) {
         options: {
           jshintrc: '.jshintrc'
         },
-        src: ['src/js/**/*.js']
+        src: 'src/js/**/*.js'
       }
     },
     sed: {
@@ -193,6 +193,11 @@ module.exports = function(grunt) {
     },
     watch: {
       files: [
+        // Force-ignore artifacts.
+        '!build',
+        '!build/**',
+        '!release',
+        '!release/**',
         '<%= jshint.package.src %>',
         '<%= jshint.gruntfile.src %>',
         '<%= jshint.js.src %>',
@@ -271,33 +276,35 @@ module.exports = function(grunt) {
   // Default tasks.
   grunt.registerTask('default', ['clean', 'less', 'css2js', 'jshint', 'concat', 'copy', 'sed']);
 
+  // Realtime development tasks.
+  // Enjoy: `grunt watch:ff`
+  // These tasks are highly tailored subsets of the default task having the goal
+  // of *instant* reloading of a newly built extension into a particular browser.
+  // The performance target is ~500ms; i.e., the time it takes a human to switch
+  // from the code editor to the browser.
+  // Note that grunt watch is not a multi-task; it supports multiple targets,
+  // but it does not support multiple tasks/sets; when running `grunt watch`,
+  // all targets are watched, and all tasks of all matching targets are executed
+  // upon a change. We do not want to tamper with the default `grunt watch` task,
+  // nor do we want to build all extensions at once (for performance reasons).
+  // The recommended informal workaround is to dynamically swap out the default
+  // config of the watch task ad-hoc.
+  // @see https://github.com/gruntjs/grunt-contrib-watch/issues/71#issuecomment-26152333
+  // Firefox.
+  grunt.registerTask('dev:ff',  ['less', 'css2js', 'jshint:js', 'concat', 'copy:firefox', 'sed']);
+  grunt.registerTask('watch:ff', function () {
+    var config = grunt.config('watch');
+    config.tasks = ['dev:ff', 'build:firefox', 'autoload:ff'];
+    // Auto-run once upon invocation.
+    config.options.atBegin = true;
+    config.options.spawn = false;
+    grunt.config('watch', config);
+    grunt.task.run('watch');
+  });
+
   // Test tasks.
   grunt.registerTask('test', ['qunit']);
   grunt.registerTask('travis-ci', ['default', 'test']);
-
-  // Autoload Firefox extension.
-  // @see https://addons.mozilla.org/en-US/firefox/addon/autoinstaller/
-  grunt.registerTask('autoload:ff', "Autoload new XPI extension in Firefox", function () {
-    var done = this.async();
-    var xpi = 'release/firefox/' + grunt.template.process('<%= pkg.name %>.xpi');
-    grunt.util.spawn({
-      cmd: 'wget',
-      args: [
-        '--post-file=' + xpi,
-        'http://localhost:8888'
-      ],
-      opts: !grunt.option('debug') ? {} : {
-        stdio: 'inherit'
-      }
-    },
-    function (error, result, code) {
-      if (code !== 8) {
-        return grunt.warn('Auto-loading ' + xpi + ' failed: (' + code + ') ' + error);
-      }
-      grunt.log.ok('Auto-loaded ' + xpi + ' into Firefox.');
-      done();
-    });
-  });
 
   // Build tasks.
   grunt.registerTask('build:chrome', ['compress:chrome']);
@@ -320,4 +327,30 @@ module.exports = function(grunt) {
     });
   });
   grunt.registerTask('build', ['default', 'compress:chrome', 'build:firefox', 'build:safari']);
+
+  // Autoload tasks.
+  // Firefox.
+  // @see https://addons.mozilla.org/en-US/firefox/addon/autoinstaller/
+  grunt.registerTask('autoload:ff', "Load XPI extension into Firefox", function () {
+    var done = this.async();
+    var xpi = 'release/firefox/' + grunt.template.process('<%= pkg.name %>.xpi');
+    grunt.util.spawn({
+      cmd: 'wget',
+      args: [
+        '--post-file=' + xpi,
+        'http://localhost:8888'
+      ],
+      opts: !grunt.option('debug') ? {} : {
+        stdio: 'inherit'
+      }
+    },
+    function (error, result, code) {
+      if (code !== 8) {
+        return grunt.warn('Auto-loading ' + xpi + ' failed: (' + code + ') ' + error);
+      }
+      grunt.log.ok('Auto-loaded ' + xpi + ' into Firefox.');
+      done();
+    });
+  });
+
 };


### PR DESCRIPTION
Requires #133.
#### Before

``` sh
$ grunt --help
Available tasks
...
           install  Alias for "mozilla-addon-sdk" task.
           default  Alias for "clean", "less", "css2js", "jshint", "concat",
                    "copy", "sed" tasks.
              test  Alias for "qunit" task.
         travis-ci  Alias for "default", "test" tasks.
       autoload:ff  Autoload new XPI extension in Firefox
      build:chrome  Alias for "compress:chrome" task.
     build:firefox  Alias for "mozilla-cfx-xpi" task.
      build:safari  Builds the safari extension
             build  Alias for "default", "compress:chrome", "build:firefox",
                    "build:safari" tasks.
```
#### After

``` sh
$ grunt --help
Available tasks
...
           install  Installs dependencies.
           default  Compiles code.
            dev:ff  Compiles code to build a Firefox extension. (see watch:ff)
          watch:ff  Enables real-time development for Firefox.
              test  Runs tests.
         travis-ci  Compiles code and runs tests.
             build  Compiles code and builds all extensions.
      build:chrome  Builds the Chrome extension.
     build:firefox  Builds the Firefox extension.
      build:safari  Builds the Safari extension.
       autoload:ff  Loads the XPI extension into Firefox.
```
