### PR TITLE
Add auto-reload/refresh support for Chrome extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,11 +181,46 @@ _Work In Progress…_ — More information on [qunit testing] coming soon.
 
 ### Chrome
 
+For real-time development:
+
+1. Run: `grunt watch:chrome`
+
+    _**Note:** A development build monitors the extension files for modifications
+    once per second. The extension will automatically reload itself in Chrome.
+    This is an **experimental** workaround, since automatic reloads are not
+    supported by Chrome (yet). — Replace the extension with a stable release to
+    ensure that the development build does not clog your browsing experience._
+
+    _@todo: Alternative approach: (requires custom updateURL + might "spam" other
+    extensions?)_
+
+        chrome --extensions-update-frequency=1
+
+1. Proceed with the steps for manual loading below.
+
+Alternatively, to manually load a single build:
+
 1. Go to [`chrome://extensions`](chrome://extensions)
 1. Enable _Developer mode_.
 1. Click on _Load unpacked extension…_
 1. Browse to the `/build/chrome` directory and click `Select`.
 1. Manually refresh the extensions page after each code change.
+
+To build and package a complete extension:
+
+1. Ensure that `openssl` is installed.
+    * Linux: `sudo apt-get install openssl`
+    * OSX: Should already exist
+    * Windows: http://www.openssl.org/related/binaries.html
+1. Ensure that `ssh-keygen` is installed.
+    * Linux/OSX: Should already exist.
+    * Windows: Bundled with git, if you have `<git-install-dir>\bin` in your PATH
+      you should be set.
+1. Run `crx keygen` or `ssh-keygen`  
+    _@todo Currently assumes `key.pem` in main directory._
+1. Run: `grunt build:chrome`
+1. Load the packed extension in Chrome from `/release/chrome/dreditor.crx`
+
 
 ### Firefox
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -228,6 +228,7 @@ module.exports = function(grunt) {
         '<%= jshint.gruntfile.src %>',
         '<%= jshint.js.src %>',
         '<%= less.files.src %>',
+        'templates/**',
         '<%= qunit.all %>'
       ],
       tasks: ['default'],
@@ -255,6 +256,17 @@ module.exports = function(grunt) {
         cwd: 'build/chrome/',
         src: ['**/*'],
         dest: '/'
+      }
+    },
+    crx: {
+      dev: {
+        src: 'build/chrome/',
+        dest: 'release/chrome/',
+        filename: '<%= pkg.name %>.crx',
+        // @todo Figure this out.
+        // @see https://github.com/oncletom/grunt-crx#documentation
+        baseURL: 'https://dreditor.org/release/chrome/',
+        //privateKey: ''
       }
     },
     "mozilla-addon-sdk": {
@@ -315,6 +327,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-qunit');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-crx');
   grunt.loadNpmTasks('grunt-css2js');
   grunt.loadNpmTasks('grunt-exec');
   grunt.loadNpmTasks('grunt-mozilla-addon-sdk');
@@ -343,6 +356,18 @@ module.exports = function(grunt) {
   // The recommended informal workaround is to dynamically swap out the default
   // config of the watch task ad-hoc.
   // @see https://github.com/gruntjs/grunt-contrib-watch/issues/71#issuecomment-26152333
+  // Chrome.
+  grunt.registerTask('dev:chrome', 'Compiles code to build a Chrome extension. (see watch:chrome)',
+    ['less', 'css2js', 'jshint:js', 'concat', 'copy:chrome', 'sed']);
+  grunt.registerTask('watch:chrome', 'Enables real-time development for Chrome.', function () {
+    var config = grunt.config('watch');
+    config.tasks = ['dev:chrome', 'build:chrome'];
+    // Auto-run once upon invocation.
+    config.options.atBegin = true;
+    config.options.spawn = false;
+    grunt.config('watch', config);
+    grunt.task.run('watch');
+  });
   // Firefox.
   grunt.registerTask('dev:ff', 'Compiles code to build a Firefox extension. (see watch:ff)',
     ['less', 'css2js', 'jshint:js', 'concat', 'copy:firefox', 'sed']);
@@ -366,7 +391,7 @@ module.exports = function(grunt) {
   grunt.registerTask('build', 'Compiles code and builds all extensions.',
     ['default', 'uglify', 'build:chrome', 'build:firefox', 'build:safari']);
   grunt.registerTask('build:chrome', 'Builds the Chrome extension.',
-    ['compress:chrome']);
+    ['crx']);
   grunt.registerTask('build:firefox', 'Builds the Firefox extension.',
     ['mozilla-cfx-xpi']);
   grunt.registerTask('build:safari', 'Builds the Safari extension.',

--- a/package.json
+++ b/package.json
@@ -52,16 +52,16 @@
     "grunt-contrib-less": "^0.8.3",
     "grunt-contrib-uglify": "^0.2.7",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-crx": "~0.3.3",
     "grunt-css2js": "~0.2.4",
     "grunt-environment": "^0.4.2",
     "grunt-exec": "^0.4.5",
     "grunt-mozilla-addon-sdk": "~0.3.2",
     "grunt-release": "^0.6.1",
-    "grunt-sed": "~0.1.1"
+    "grunt-sed": "~0.1.1",
+    "jshint-stylish": "^0.2.0"
   },
   "optionalDependencies": {
     "grunt-contrib-qunit": ">=0.2.1",
-    "jshint-stylish": "^0.2.0",
-    "grunt-crx": "~0.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,10 +57,11 @@
     "grunt-exec": "^0.4.5",
     "grunt-mozilla-addon-sdk": "~0.3.2",
     "grunt-release": "^0.6.1",
-    "grunt-sed": "~0.1.1",
-    "jshint-stylish": "^0.2.0"
+    "grunt-sed": "~0.1.1"
   },
   "optionalDependencies": {
-    "grunt-contrib-qunit": ">=0.2.1"
+    "grunt-contrib-qunit": ">=0.2.1",
+    "jshint-stylish": "^0.2.0",
+    "grunt-crx": "~0.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "jshint-stylish": "^0.2.0"
   },
   "optionalDependencies": {
-    "grunt-contrib-qunit": ">=0.2.1",
+    "grunt-contrib-qunit": ">=0.2.1"
   }
 }

--- a/templates/chrome/autoreload.js
+++ b/templates/chrome/autoreload.js
@@ -1,0 +1,44 @@
+
+/**
+ * @file
+ * Chrome extension autoreload.
+ */
+
+// @todo Replace with template name.
+var watchurl = chrome.extension.getURL('dreditor.js');
+var storage = chrome.storage.local;
+var lastEtag, newEtag;
+
+// @todo This is aynchronous...
+storage.get('autoreload.etag', function (items) {
+  lastEtag = items['autoreload.etag'];
+});
+
+/**
+ * Performs a HEAD request to the specified watch URL to compare its ETag.
+ *
+ * Idea borrowed from Live.js.
+ * @see http://livejs.com/
+ */
+setInterval(function () {
+  console.log('HEAD ' + watchurl);
+
+  var xhr = new XMLHttpRequest();
+  xhr.open('HEAD', watchurl, true);
+  xhr.onreadystatechange = function () {
+    newEtag = xhr.getResponseHeader('etag');
+    if (lastEtag != newEtag) {
+      console.log('Reloading extension. ETag %s != %s', lastEtag, newEtag);
+      storage.set({ 'autoreload.etag': newEtag });
+      chrome.runtime.reload();
+      // Execution ends here.
+    }
+  }
+  xhr.send();
+
+  // Use a reasonable timeout to pick up changes immediately.
+  // An extension build takes ~1.1 sec.
+  // Refreshing too fast may cause the manifest.json template to not be
+  // post-processed yet.
+  // @see Gruntfile.js
+}, 1000);

--- a/templates/chrome/manifest.json
+++ b/templates/chrome/manifest.json
@@ -17,8 +17,11 @@
     }
   ],
   "permissions": [
-    "*://*.drupal.org/*",
-    "*://*.dreditor.org/*",
-    "*://*.devdrupal.org/*"
-  ]
+    "storage"
+  ],
+  "background": {
+    "scripts": [
+      "autoreload.js"
+    ]
+  }
 }


### PR DESCRIPTION
# Experimental

This branch/PR adds auto-reload/refresh support for the Chrome extension.

Researched + investigated many ideas and options.  Took inspiration from http://livejs.com/

This totally works, but is incomplete in multiple ways:
1. The additional code in `manifest.json` needs to be limited to development builds.
2. The `[grunt-]crx` changes are theoretically off-topic now, as they turned out to be unnecessary in the end.
3. The added code and documentation contains `@todos`

---

This is a public feature branch to enable collaboration + PRs.  Do not rebase this branch; only add commits (or ideally merge PRs against it).
