### PR TITLE
Fixed commit message feature after d.o D7 upgrade.

### DIFF
--- a/src/js/plugins/commit.message.js
+++ b/src/js/plugins/commit.message.js
@@ -109,16 +109,20 @@ Drupal.behaviors.dreditorCommitMessage = {
         }
 
         // Build title.
-        var title = Drupal.dreditor.issue.getIssueTitle();
+        // Use the text input field value to allow maintainers to adjust it
+        // prior to commit.
+        var title = $('#edit-title').val();
 
         // Add "Added|Fixed " prefix based on issue category.
-        switch ($('#edit-category').val()) {
+        switch ($('#edit-field-issue-category-und').val()) {
           case 'bug':
+          case '1':
             title = title.replace(/^fix\S*\s*/i, '');
             title = 'Fixed ' + title;
             break;
 
           case 'feature':
+          case '3':
             title = title.replace(/^add\S*\s*/i, '');
             title = 'Added ' + title;
             break;


### PR DESCRIPTION
1. An adjusted issue title is no longer taken over as commit message.
2. The commit message is no longer prefixed with Added|Fixed depending on issue category.
