### PR TITLE
Fixed patch reviewer does not highlight YAML comments.

### DIFF
--- a/src/js/plugins/patch.review.js
+++ b/src/js/plugins/patch.review.js
@@ -535,7 +535,7 @@ Drupal.dreditor.patchReview.behaviors.setup = function (context, code) {
       }
     }
     // Colorize comments.
-    if (syntax && line.match(/^.\s*\/\/|^.\s*\/\*[\* ]|^.\s+\*/)) {
+    if (syntax && line.match(/^.\s*\/\/|^.\s*\/\*[\* ]|^.\s+\*|^.\s*#/)) {
       classes.push('comment');
     }
 


### PR DESCRIPTION
Apparently also applies to PHP comments.

IIRC, I only ignored that PHP comment syntax originally, because it's not part of Drupal's coding standards.

Therefore, this fixes both YAML + PHP comments using the alternative syntax.
