### PR TITLE
Support powerful/smart commit messages

### DIFF
--- a/src/js/plugins/commit.message.js
+++ b/src/js/plugins/commit.message.js
@@ -96,7 +96,7 @@ Drupal.behaviors.dreditorCommitMessage = {
         // @todo Add configuration option for prefix. For now, manually override:
         //   Drupal.storage.save('commitmessage.prefix', '-');
         var prefix = Drupal.storage.load('commitmessage.prefix');
-        prefix = (prefix ? prefix : 'Fix');
+        prefix = (prefix ? prefix : 'Fixed');
         var message = self.generateCommitMessage(
           prefix,
           Drupal.dreditor.issue.getNid(),

--- a/src/js/plugins/commit.message.js
+++ b/src/js/plugins/commit.message.js
@@ -93,50 +93,20 @@ Drupal.behaviors.dreditorCommitMessage = {
           });
         }
         // Build commit message.
-        var prefix = 'Fix';
-        var message = prefix + ' #' + Drupal.dreditor.issue.getNid() + ' ';
-        message += 'by ' + submitters.join(', ');
-        if (contributors.length) {
-          if (submitters.length) {
-            message += ' | ';
-          }
-          // Add a separator between patch submitters and commenters.
-          message += contributors.join(', ');
-        }
-
-        // Build title.
-        // Use the text input field value to allow maintainers to adjust it
-        // prior to commit.
-        var title = $('#edit-title').val();
-
-        // Adjust title based on issue category.
-        switch ($('#edit-field-issue-category-und').val()) {
-          case 'bug':
-          case '1':
-            // Remove 'fix*' from title to not duplicate initial prefix.
-            title = title.replace(/^fix\S*\s*/i, '');
-            break;
-
-          case 'feature':
-          case '3':
-            // Replace 'add*' with consistent + properly capitalized prefix.
-            title = title.replace(/^add\S*\s*/i, '');
-            title = 'Added ' + title;
-            break;
-
-          default:
-            // For anything else, we just ensure proper capitalization.
-            if (title[0].toLowerCase() === title[0]) {
-              title = title[0].toUpperCase() + title.substring(1);
-            }
-            break;
-        }
-
-        // Add a period (full-stop).
-        if (title[title.length - 1] !== '.') {
-          title += '.';
-        }
-        message += ': ' + title;
+        // @todo Add configuration option for prefix. For now, manually override:
+        //   Drupal.storage.save('commitmessage.prefix', '-');
+        var prefix = Drupal.storage.load('commitmessage.prefix');
+        prefix = (prefix ? prefix : 'Fix');
+        var message = self.generateCommitMessage(
+          prefix,
+          Drupal.dreditor.issue.getNid(),
+          // Use the text input field value to allow maintainers to adjust it
+          // prior to commit.
+          $('#edit-title').val(),
+          $('#edit-field-issue-category-und').val(),
+          submitters,
+          contributors
+        );
 
         // Inject a text field.
         var $input = $('#dreditor-commitmessage-input', context);
@@ -218,5 +188,65 @@ Drupal.behaviors.dreditorCommitMessage = {
       });
       $link.prependTo($container);
     });
+  },
+
+  /**
+   * Generates a commit message string.
+   *
+   * @param string prefix
+   *   The message prefix; e.g., "Fix".
+   * @param int|string issueID
+   *   The ID of the issue (without "#").
+   * @param string title
+   *   The issue title.
+   * @param string category
+   *   The issue category; one of: 'bug' (1), 'feature' (3), 'task' (2).
+   * @param array submitters
+   *   Ordered list of usernames who submitted patches.
+   * @param array contributors
+   *   Ordered list of usernames who contributed. May be empty.
+   */
+  generateCommitMessage: function (prefix, issueID, title, category, submitters, contributors) {
+    var message = prefix + ' #' + issueID + ' ';
+
+    message += 'by ' + submitters.join(', ');
+    if (contributors.length) {
+      // Add a separator between patch submitters and commenters.
+      if (submitters.length) {
+        message += ' | ';
+      }
+      message += contributors.join(', ');
+    }
+
+    // Adjust title based on issue category.
+    switch (category) {
+      case 'bug':
+      case '1':
+        // Remove 'fix*' from title to not duplicate initial prefix.
+        title = title.replace(/^fix\S*\s*/i, '');
+        break;
+
+      case 'feature':
+      case '3':
+        // Replace 'add*' with consistent + properly capitalized prefix.
+        title = title.replace(/^add\S*\s*/i, '');
+        title = 'Added ' + title;
+        break;
+
+      default:
+        // For anything else, we just ensure proper capitalization.
+        if (title[0].toLowerCase() === title[0]) {
+          title = title[0].toUpperCase() + title.substring(1);
+        }
+        break;
+    }
+
+    // Add a period (full-stop).
+    if (title[title.length - 1] !== '.') {
+      title += '.';
+    }
+    message += ': ' + title;
+
+    return message;
   }
 };

--- a/src/js/plugins/commit.message.js
+++ b/src/js/plugins/commit.message.js
@@ -93,11 +93,7 @@ Drupal.behaviors.dreditorCommitMessage = {
           });
         }
         // Build commit message.
-        // @todo Add configuration option for prefix. For now, manually override:
-        //   Drupal.storage.save('commitmessage.prefix', '-');
-        var prefix = Drupal.storage.load('commitmessage.prefix');
-        prefix = (prefix ? prefix : 'Issue');
-
+        var prefix = 'Fix';
         var message = prefix + ' #' + Drupal.dreditor.issue.getNid() + ' ';
         message += 'by ' + submitters.join(', ');
         if (contributors.length) {
@@ -113,16 +109,17 @@ Drupal.behaviors.dreditorCommitMessage = {
         // prior to commit.
         var title = $('#edit-title').val();
 
-        // Add "Added|Fixed " prefix based on issue category.
+        // Adjust title based on issue category.
         switch ($('#edit-field-issue-category-und').val()) {
           case 'bug':
           case '1':
+            // Remove 'fix*' from title to not duplicate initial prefix.
             title = title.replace(/^fix\S*\s*/i, '');
-            title = 'Fixed ' + title;
             break;
 
           case 'feature':
           case '3':
+            // Replace 'add*' with consistent + properly capitalized prefix.
             title = title.replace(/^add\S*\s*/i, '');
             title = 'Added ' + title;
             break;

--- a/tests/src/js/plugins/commit.message.html
+++ b/tests/src/js/plugins/commit.message.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+
+<title>Commit message tests</title>
+
+<script type="text/javascript" src="http://code.jquery.com/jquery-1.4.4.min.js"></script>
+<script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>
+<link rel="stylesheet" type="text/css" href="http://code.jquery.com/qunit/qunit-1.12.0.css">
+
+<!-- @todo Move basic setup + extensions into test helper script. -->
+<script>
+Drupal = {
+  behaviors: {}
+};
+
+QUnit.assert.startsWith = function (needle, hayStack) {
+  var actual = hayStack.indexOf(needle) === 0;
+  QUnit.push(actual, hayStack, needle, "'" + hayStack + "' starts with '" + needle + "'");
+};
+QUnit.assert.contains = function (needle, hayStack) {
+  var actual = hayStack.indexOf(needle) > -1;
+  QUnit.push(actual, hayStack, needle, "'" + hayStack + "' contains '" + needle + "'");
+};
+</script>
+
+<script type="text/javascript" src="../../../../src/js/plugins/commit.message.js"></script>
+<script>
+module("dreditorCommitMessage");
+
+test("generateCommitMessage", function (assert) {
+  var unit = Drupal.behaviors.dreditorCommitMessage.generateCommitMessage;
+  var prefix = 'Fix';
+  var id = 123;
+  var submitters = ['sun'], contributors = [];
+
+  var actual, i;
+
+  // Prefix is prepended, followed by a space.
+  actual = unit('Prefix', id, 'title', 'bug', submitters, contributors);
+  assert.startsWith('Prefix ', actual);
+
+  // Issue ID is prefixed with "#".
+  actual = unit('Fix', 123, 'title', 'bug', submitters, contributors);
+  assert.startsWith('Fix #123 ', actual);
+
+  // Submitters are prefixed with "by ".
+  actual = unit('Fix', 123, 'title', 'bug', ['name'], contributors);
+  assert.startsWith('Fix #123 by name: ', actual);
+  // Submitters are listed delimited by comma.
+  actual = unit('', 0, 'title', 'bug', ['first', 'second'], contributors);
+  assert.contains('by first, second:', actual);
+
+  // Contributors are listed delimited by comma.
+  actual = unit('Fix', 1, 'title', 'bug', [], ['name']);
+  assert.contains('by name:', actual);
+  actual = unit('Fix', 1, 'title', 'bug', [], ['first', 'second']);
+  assert.contains('by first, second:', actual);
+
+  // Contributors are separated from submitters.
+  actual = unit('Fix', 1, 'title', 'bug', ['submitter'], ['contributor']);
+  assert.contains('by submitter | contributor:', actual);
+
+  // "Fix*" is removed from title of bug reports.
+  ["Fix", "fix", "Fixes", "fixes", "Fixed", "fixed", "Fixing", "fixing"]
+    .forEach(function (test) {
+      actual = unit('Fix', 1, test + ' something', 'bug', [], []);
+      assert.contains(': something', actual);
+
+      // ...but not from non-bugs.
+      var title = test + ' something';
+      actual = unit('Fix', 1, title, 'task', [], []);
+      title = title[0].toUpperCase() + title.substring(1);
+      assert.contains(': ' + title, actual);
+    });
+
+  // "Add*" is replaced with "Added" in title of feature requests.
+  ["Add", "add", "Adds", "adds", "Added", "added", "Adding", "adding"]
+    .forEach(function (test) {
+      actual = unit('Fix', 1, test + ' something', 'feature', [], []);
+      assert.contains(': Added something', actual);
+
+      // ...but not for non-features.
+      var title = test + ' something';
+      actual = unit('Fix', 1, title, 'task', [], []);
+      title = title[0].toUpperCase() + title.substring(1);
+      assert.contains(': ' + title, actual);
+    });
+
+  // Title is capitalized for non-bug/feature categories.
+  actual = unit('Fix', 1, 'some thing', '-', [], []);
+  assert.contains(': Some thing', actual);
+
+  // Title ends in a period.
+  actual = unit('Fix', 1, 'title', '-', [], []);
+  assert.contains(': Title.', actual);
+
+});
+</script>
+</head>
+<body>
+<div id="qunit"></div> <!-- QUnit results -->
+<div id="qunit-fixture"> <!-- HTML fixtures; reset for each test -->
+
+</div>
+</body>
+</html>
+


### PR DESCRIPTION
cf. https://drupal.org/node/2270763

Live example:

``` diff
-Issue #2269385 by sun: Fixed DependencyInjection YamlFileLoader is out of date.
+Fixed #2269385 by sun: DependencyInjection YamlFileLoader is out of date.
```

---

~~Problematic / todo:~~

UPDATE: Bogus manual testing result; the issue in question is a task, and "fix*" is only stripped from bug reports.

``` diff
-Issue #2254203 by sun: Fix test performance of Drupal\system\Tests\Module\ModuleApiTest.
+Fixed #2254203 by sun: Fix test performance of Drupal\system\Tests\Module\ModuleApiTest.
```

should be:

``` diff
+Fixed #2254203 by sun: Test performance of Drupal\system\Tests\Module\ModuleApiTest.
```

…can't do anything about poor issue titles like that, but _"Fixed"_ should not be repeated + title _should_ start capitalized.
