### PR TITLE
Commit message git attribution does not work with URL aliases

### DIFF
--- a/src/js/plugins/commit.message.js
+++ b/src/js/plugins/commit.message.js
@@ -56,7 +56,7 @@ Drupal.behaviors.dreditorCommitMessage = {
         var users = {};
         $submitters.each(function () {
           users[this.textContent] = {
-            id: this.getAttribute('data-uid'), // unused.
+            id: this.getAttribute('data-uid'),
             name: this.textContent,
             href: this.href
           };
@@ -170,7 +170,7 @@ Drupal.behaviors.dreditorCommitMessage = {
           // Add user list as commit attribution choices.
           var user;
           for (user in users) {
-            var $userLink = $('<a href="#' + users[user].href + '/git-attribution" class="choice">' + users[user].name + '</a>')
+            var $userLink = $('<a href="#/user/' + users[user].id + '/git-attribution" class="choice">' + users[user].name + '</a>')
               .data('user', users[user]);
             $userLink.click(function () {
               var link = this;

--- a/src/js/plugins/commit.message.js
+++ b/src/js/plugins/commit.message.js
@@ -56,6 +56,7 @@ Drupal.behaviors.dreditorCommitMessage = {
         var users = {};
         $submitters.each(function () {
           users[this.textContent] = {
+            id: this.getAttribute('data-uid'), // unused.
             name: this.textContent,
             href: this.href
           };


### PR DESCRIPTION
Follow-up to #164 + #165

Forgot to test the git attribution feature.  The `/user/<uid>/git-attribution` JSON callback is not available as aliased URL.
