### PR TITLE
Add new badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# Dreditor
-[![build](https://travis-ci.org/dreditor/dreditor.png?branch=1.x)](https://travis-ci.org/dreditor/dreditor)
+# Dreditor [![GitHub version](https://badge.fury.io/gh/dreditor%2Fdreditor.svg)](http://badge.fury.io/gh/dreditor%2Fdreditor) [![Show some love](http://img.shields.io/gittip/Dreditor.svg)](https://www.gittip.com/Dreditor)
+[![Built with NodeJS](http://pixel-cookers.github.io/built-with-badges/node/node-short.png)](http://nodejs.org/)
+[![Built with Grunt](http://pixel-cookers.github.io/built-with-badges/grunt/grunt-short.png)](http://gruntjs.com/)
+[![Build Status](https://travis-ci.org/dreditor/dreditor.svg?branch=1.x)](https://travis-ci.org/dreditor/dreditor)
+[![Dependency Status](https://david-dm.org/dreditor/dreditor.svg)](https://david-dm.org/dreditor/dreditor)
+[![devDependency Status](https://david-dm.org/dreditor/dreditor/dev-status.svg)](https://david-dm.org/dreditor/dreditor#info=devDependencies)
+[![Code Climate](http://img.shields.io/codeclimate/github/dreditor/dreditor.svg)](https://codeclimate.com/github/dreditor/dreditor)
 
 A web browser extension for Drupal.org that enhances user experience and
 functionality.


### PR DESCRIPTION
Next to title:
- Added "version" badge.
- Added "gittip" badge.

Underneath title:
- Added "node" badge.
- Added "grunt" badge.
- Updated "build" badge (travis-ci) to use SVG instead of PNG.
- Added "dependency" badges (david-dm).
- Added "code-climate" badge.
