### PR TITLE
Expose the predicted number of a new comment

### DIFF
--- a/src/js/plugins/comment.number.js
+++ b/src/js/plugins/comment.number.js
@@ -1,0 +1,14 @@
+/**
+ * Exposes the predicted number for a new comment.
+ *
+ * The (sequential) comment number is commonly used as suffix in patch names.
+ * This plugin simply exposes the predicted new comment number in the
+ * "Add new comment" heading of the issue comment/update form (block), so that
+ * contributors do not have to manually make the math.
+ */
+Drupal.behaviors.dreditorCommentNumber = {
+  attach: function (context) {
+    $(context).find('#block-project-issue-issue-edit h2')
+      .append(' #' + Drupal.dreditor.issue.getNewCommentNumber());
+  }
+};

--- a/src/js/plugins/issue.js
+++ b/src/js/plugins/issue.js
@@ -12,14 +12,11 @@ Drupal.dreditor.issue.getNid = function() {
 
 /**
  * Returns the next comment number for the current issue.
- *
- * @todo Use reliable JSON data instead of scraping the DOM (which can change).
- * @see https://drupal.org/node/1710850
  */
 Drupal.dreditor.issue.getNewCommentNumber = function() {
   // Get comment count.
   var lastCommentNumber = $('.comments .comment:last .permalink').text().match(/\d+$/);
-  return lastCommentNumber ? parseInt(lastCommentNumber[0], 10) : undefined;
+  return (lastCommentNumber ? parseInt(lastCommentNumber[0], 10) : 0) + 1;
 };
 
 /**

--- a/src/js/plugins/patch.name.suggestion.js
+++ b/src/js/plugins/patch.name.suggestion.js
@@ -33,12 +33,7 @@ Drupal.behaviors.dreditorPatchNameSuggestion = {
         if (nid !== 0) {
           patchName += (patchName.length ? '-' : '') + nid;
         }
-
-        var newCommentNumber = Drupal.dreditor.issue.getNewCommentNumber();
-        if (typeof newCommentNumber !== 'undefined') {
-          patchName += '-' + newCommentNumber;
-        }
-
+        patchName += '-' + Drupal.dreditor.issue.getNewCommentNumber();
         patchName += '.patch';
 
         window.prompt("Please use this value", patchName);


### PR DESCRIPTION
This was originally part of the `issue.comment.form` plugin, which was removed in 6dbdcc3 (after the d.o major upgrade to D7).

It not only saves you from doing the math manually, it also avoids needless scrolling (since the heading is more likely to be in the visible viewport).

Testing revealed that the current implementation of `issue.getNewCommentNumber()` is completely bogus.
