### PR TITLE
inline.image plugin operates on countless of .file DOM elements of patchReviewer

### DIFF
--- a/src/js/plugins/inline.image.js
+++ b/src/js/plugins/inline.image.js
@@ -6,7 +6,8 @@ Drupal.behaviors.dreditorInlineImage = {
     var $context = $(context);
     var $comment = $(':input[name="nodechanges_comment_body[value]"]');
 
-    $context.find('.file').once('dreditor-inlineimage').find('> a').each(function () {
+    // @todo .file clashes with patchReviewer tr.file + a.file markup.
+    $context.find('span.file').once('dreditor-inlineimage').find('> a').each(function () {
       var $link = $(this);
 
       // Remove protocol + drupal.org


### PR DESCRIPTION
Affects #5

This is a just quickfix to get into the next patch stable release for now.  I did already dig a lot deeper, but adjusting the code to no longer be triggered in the first place requires some major architectural rethinking + a proper plan.
