### PR TITLE
Predicted new comment number is hard to recognize visually

### DIFF
--- a/src/js/plugins/comment.number.js
+++ b/src/js/plugins/comment.number.js
@@ -9,6 +9,6 @@
 Drupal.behaviors.dreditorCommentNumber = {
   attach: function (context) {
     $(context).find('#block-project-issue-issue-edit h2')
-      .append(' #' + Drupal.dreditor.issue.getNewCommentNumber());
+      .append(' <strong>#' + Drupal.dreditor.issue.getNewCommentNumber() + '</strong>');
   }
 };


### PR DESCRIPTION
Advances on #189

The predicted new comment number is super helpful.

However, it appears in a different spot than the numbers of existing comments, so my brain always needs an additional cycle to remember where it is located + recognize it.

For now, I'd like to propose to quickly fix the recognition problem only by making it appear in bold:

![dreditor-new-comment-number](https://cloud.githubusercontent.com/assets/41992/3152161/935bf6c4-ea8a-11e3-98b3-f60012953353.png)
