### PR TITLE
Minor patchreviewer cleanups

### DIFF
--- a/src/js/plugins/patch.review.js
+++ b/src/js/plugins/patch.review.js
@@ -448,7 +448,6 @@ Drupal.dreditor.patchReview.behaviors.setup = function (context, code) {
   for (var n in code) {
     var ln1o = true;
     var ln2o = true;
-    var prettify_line = true;
     var line = code[n];
 
     // Build file menu links.
@@ -479,7 +478,6 @@ Drupal.dreditor.patchReview.behaviors.setup = function (context, code) {
       classes.push('file');
       ln1o = false;
       ln2o = false;
-      prettify_line = false;
     }
     // Colorize old code, but skip file diff lines.
     else if (line.match(/^((?!\-\-\-$|\-\-$)\-.*)$/)) {

--- a/src/js/plugins/patch.review.js
+++ b/src/js/plugins/patch.review.js
@@ -483,6 +483,7 @@ Drupal.dreditor.patchReview.behaviors.setup = function (context, code) {
     else if (line.match(/^((?!\-\-\-$|\-\-$)\-.*)$/)) {
       classes.push('old');
       diffstat.deletions++;
+      syntax = true;
       if (ln1) {
         ln2o = false;
         ln1++;
@@ -521,10 +522,6 @@ Drupal.dreditor.patchReview.behaviors.setup = function (context, code) {
       line = '<span class="error eof">' + line + '</span>';
     }
     else {
-      // @todo Also colorizing unchanged lines makes added comments almost
-      // invisible. Although we could use .new.comment as CSS selector, the
-      // question of a sane color scheme remains.
-      // syntax = true;
       if (ln1 && ln1o) {
         ln1++;
       }

--- a/src/less/dreditor.less
+++ b/src/less/dreditor.less
@@ -138,7 +138,7 @@
   content: attr(data-line-number);
 }
 #dreditor #code tr {
-  background: transparent;
+  background-color: transparent;
   border: 0;
   color: #888;
   margin: 0;
@@ -146,8 +146,6 @@
 }
 #dreditor #code .pre {
   white-space: pre;
-  background: transparent;
-  position: relative;
 }
 #dreditor #code thead .line-ruler {
   border-left: 1px solid rgba(0,0,0,0.15);
@@ -183,8 +181,8 @@
   display: none;
 }
 #dreditor #code tr.file {
-  color: #064A6F;
   background-color: #E8F1F6;
+  color: #064A6F;
 }
 #dreditor #code tr.file a {
   color: #064A6F;
@@ -195,10 +193,10 @@
 }
 #dreditor #code tr.old {
   background-color: #fdd;
-  color: #CC0000;
+  color: #c00;
 }
 #dreditor #code tr.old a {
-  color: #CC0000;
+  color: #c00;
 }
 #dreditor #code tr.old .ln {
   background-color: #f7c8c8;


### PR DESCRIPTION
1. Removed unused prettify_line variable.
2. Classify old diff lines containing a comment as '.old.comment'.
3. Minor diff style cleanups (no visual changes).
