### PR TITLE
Highlight renames and copies in patchreviewer

### DIFF
--- a/src/js/plugins/patch.review.js
+++ b/src/js/plugins/patch.review.js
@@ -474,10 +474,17 @@ Drupal.dreditor.patchReview.behaviors.setup = function (context, code) {
 
     var classes = [], syntax = false;
     // Colorize file diff lines.
-    if (line.match(/^((index|===|RCS|new file mode|deleted file mode|retrieving|diff|\-\-\-\s|\-\-\s|\+\+\+\s|@@\s).*)$/i)) {
+    if (line.match(/^((index|===|RCS|new file mode|deleted file mode|similarity|rename|copy|retrieving|diff|\-\-\-\s|\-\-\s|\+\+\+\s|@@\s).*)$/i)) {
       classes.push('file');
       ln1o = false;
       ln2o = false;
+      // Renames and copies are easy to miss; colorize them.
+      if (line.match(/^rename from|^copy from/)) {
+        classes.push('old');
+      }
+      else if (line.match(/^rename to|^copy to/)) {
+        classes.push('new');
+      }
     }
     // Colorize old code, but skip file diff lines.
     else if (line.match(/^((?!\-\-\-$|\-\-$)\-.*)$/)) {


### PR DESCRIPTION
`renames=copies` is part of the [recommended git configuration](https://drupal.org/node/1542048).

However, it's easy to not recognize that a file is renamed/copied, since the diff file headers are "greyed out".

This PR adds explicit highlighting for both cases:

![dreditor-highlight-renames](https://cloud.githubusercontent.com/assets/41992/3162619/138055be-eb37-11e3-9320-46656772b5e9.png)

_Sorry, screenshot additionally has #59 applied, but you get the point._
