### PR TITLE
Changed /drupal.org into /www.drupal.org.

### DIFF
--- a/src/js/extensions/storage.js
+++ b/src/js/extensions/storage.js
@@ -1,7 +1,7 @@
 /**
  * Drupal HTML5 storage handler.
  *
- * @see http://drupal.org/node/65578
+ * @see http://www.drupal.org/node/65578
  */
 Drupal.storage = {};
 

--- a/src/js/extensions/storage.js
+++ b/src/js/extensions/storage.js
@@ -1,7 +1,7 @@
 /**
  * Drupal HTML5 storage handler.
  *
- * @see http://www.drupal.org/node/65578
+ * @see https://www.drupal.org/node/65578
  */
 Drupal.storage = {};
 

--- a/src/js/plugins/patch.name.suggestion.js
+++ b/src/js/plugins/patch.name.suggestion.js
@@ -1,7 +1,7 @@
 /**
  * Suggest a filename for patches to upload in an issue.
  *
- * Developed in issue: http://drupal.org/node/1294662
+ * Developed in issue: http://www.drupal.org/node/1294662
  */
 Drupal.behaviors.dreditorPatchNameSuggestion = {
   attach: function (context) {

--- a/src/js/plugins/patch.name.suggestion.js
+++ b/src/js/plugins/patch.name.suggestion.js
@@ -1,7 +1,7 @@
 /**
  * Suggest a filename for patches to upload in an issue.
  *
- * Developed in issue: http://www.drupal.org/node/1294662
+ * Developed in issue: https://www.drupal.org/node/1294662
  */
 Drupal.behaviors.dreditorPatchNameSuggestion = {
   attach: function (context) {

--- a/src/js/plugins/syntax.autocomplete.js
+++ b/src/js/plugins/syntax.autocomplete.js
@@ -193,7 +193,7 @@ Drupal.dreditor.syntaxAutocomplete.prototype.suggestions.html = {
  */
 Drupal.dreditor.syntaxAutocomplete.prototype.suggestions.issue = function (needle) {
   var matches;
-  if (matches = needle.match('^https?://drupal.org/node/([0-9]+)')) {
+  if (matches = needle.match('^https?://www.drupal.org/node/([0-9]+)')) {
     return '[#' + matches[1] + ']^';
   }
   return false;

--- a/src/js/plugins/syntax.autocomplete.js
+++ b/src/js/plugins/syntax.autocomplete.js
@@ -193,7 +193,7 @@ Drupal.dreditor.syntaxAutocomplete.prototype.suggestions.html = {
  */
 Drupal.dreditor.syntaxAutocomplete.prototype.suggestions.issue = function (needle) {
   var matches;
-  if (matches = needle.match('^https?://www.drupal.org/node/([0-9]+)')) {
+  if (matches = needle.match('^https?://.+/node/([0-9]+)')) {
     return '[#' + matches[1] + ']^';
   }
   return false;


### PR DESCRIPTION
Somehow d.o now has **www.** prefixed. Dreditor breaks with 

> XMLHttpRequest cannot load https://drupal.org/node/1120672. No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'https://www.drupal.org/' is therefore not allowed access.

That is for my #93 

This PR only changes other files.
