### PR TITLE
Restore removing the domain when embedding images

### DIFF
--- a/src/js/plugins/inline.image.js
+++ b/src/js/plugins/inline.image.js
@@ -11,7 +11,7 @@ Drupal.behaviors.dreditorInlineImage = {
       var $link = $(this);
 
       // Remove protocol + drupal.org
-      var url = $link.attr('href').replace(/^https\:\/\/drupal\.org/, '');
+      var url = $link.attr('href').replace(/^https\:\/\/(?:www\.)?drupal\.org/, '');
 
       // Only process image attachments.
       if (!$comment.length || !url.match(/\.png$|\.jpg$|\.jpeg$|\.gif$/)) {


### PR DESCRIPTION
Another change for www.drupal.org vs. drupal.org.
