### PR TITLE
Load only on Drupal 7 sites

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -23,7 +23,7 @@ if (window.jQuery !== undefined && window.jQuery.fn.jquery >= '1.4.4' && window.
 
 jQuery(document).ready(function () {
   // If we are on a Drupal 7 site (i.e: not localize.drupal.org)
-  if (Drupal.ajax) {
+  if (Drupal.detachBehaviors) {
     Drupal.attachBehaviors(this);
   }
 });

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -22,7 +22,10 @@ if (window.jQuery !== undefined && window.jQuery.fn.jquery >= '1.4.4' && window.
 }
 
 jQuery(document).ready(function () {
-  Drupal.attachBehaviors(this);
+  // If we are on a Drupal 7 site (i.e: not localize.drupal.org)
+  if (Drupal.ajax) {
+    Drupal.attachBehaviors(this);
+  }
 });
 
 // Invoke Dreditor update check once.


### PR DESCRIPTION
The test for Drupal.ajax fix loading on old Drupal 6 sites (like localize.drupal.org) where behaviors have a different structure.

On localize.drupal.org I get a `Uncaught TypeError: object is not a function` in

``` JavaScript
Drupal.attachBehaviors = function(context) {
  context = context || document;
  // Execute all of them.
  jQuery.each(Drupal.behaviors, function() {
    this(context);
  });
};
```
