### PR TITLE
Remove github as source for mozilla_addon_sdk

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -274,7 +274,6 @@ module.exports = function(grunt) {
       'release': {
         options: {
           revision: "1.16",
-          github: true
         }
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -273,7 +273,7 @@ module.exports = function(grunt) {
     "mozilla-addon-sdk": {
       'release': {
         options: {
-          revision: "1.16",
+          revision: "1.16"
         }
       }
     },


### PR DESCRIPTION
This is necessary so it actually pulls the published release. During the submission process on http://addons.mozilla.org, I got a warning that the SDK version `16.0-dev` was not the current `16.0` version and that some APIs may not work. Turns out that the releases on GH include this version modifier and are removed from the official releases on their FTP server.

If you already have the SDK installed (most likely), you will will need to remove it and re-install the correct one:

``` sh
$ rm -r ./tmp/mozilla-addon-sdk
$ grunt install
```
