### PR TITLE
Fix incorrect order of commit message in Safari

### DIFF
--- a/src/js/plugins/commit.message.js
+++ b/src/js/plugins/commit.message.js
@@ -35,7 +35,7 @@ Drupal.behaviors.dreditorCommitMessage = {
               temp.push([ counts[key], key ]);
             }
             temp.sort(function (a, b) {
-              return a[0] > b[0];
+              return a[0] - b[0];
             });
             // Return the list of values, ordered by counts (descending).
             var result = [];


### PR DESCRIPTION
Fixes #226.

Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort, sort functions should return less than zero, zero, or greater than zero to determine the sort order, not a boolean value. We were getting away with this in Chrome and Firefox but it seems like newer versions of Safari are stricter on this.

Tested:
- Safari 7.0.6
- Chrome 37.0.2062.94
- Firefox 31.0

All on OS X 10.9.4.
