### PR TITLE
Rename "Insert novice tasks" button to "Insert tasks"

### DIFF
--- a/src/js/plugins/issue.summary.template.js
+++ b/src/js/plugins/issue.summary.template.js
@@ -20,12 +20,12 @@ Drupal.behaviors.dreditorIssueSummaryTemplate = {
           self.insertSummaryTemplate($textarea);
         });
 
-      // Add a button to insert novice tasks.
-      $('<a href="#" class="dreditor-button" style="margin-left: 10px;">Insert novice tasks</a>')
+      // Add a button to insert tasks.
+      $('<a href="#" class="dreditor-button" style="margin-left: 10px;">Insert tasks</a>')
         .appendTo($label)
         .bind('click', function (e) {
           e.preventDefault();
-          self.insertNoviceTasks($textarea);
+          self.insertTasks($textarea);
         });
     });
   },
@@ -79,7 +79,7 @@ Drupal.behaviors.dreditorIssueSummaryTemplate = {
       $textarea.val(template + $textarea.val());
     });
   },
-  insertNoviceTasks: function ($textarea) {
+  insertTasks: function ($textarea) {
     $.get('/node/2272209', function (data) {
       // Retrieve the template.
       var $template = $('<div/>').html($(data).find('#node-2272209 code').text());


### PR DESCRIPTION
The template has a column to indicate whether a task is novice or not, so the task template is useful for all tasks.

Credit goes to @YesCT at BADCamp for the idea.
