### PR TITLE
Fix for previousSibling not defined when pasting patch review

### DIFF
--- a/src/js/plugins/patch.review.js
+++ b/src/js/plugins/patch.review.js
@@ -224,6 +224,11 @@ Drupal.dreditor.patchReview = {
         return true;
       }
       var $elements = $(this.elements);
+      // Skip comments with no corresponding lines.
+      var firstLine = $elements.get(0);
+      if (!firstLine) {
+        return true;
+      }
       var markup = '<code>\n';
       // Add file information.
       var lastfile = $elements.eq(0).prevAll('tr.file:has(a.file)').get(0);
@@ -236,7 +241,7 @@ Drupal.dreditor.patchReview = {
         markup += lasthunk.textContent + '\n';
       }
 
-      var lastline = $elements.get(0).previousSibling;
+      var lastline = firstLine.previousSibling;
       var lastfileNewlineAdded;
 
       $elements.each(function () {


### PR DESCRIPTION
This is a quick fix for #223. There is a more fundamental UI issue to be solved (below) but this is a quick fix/patch for the immediate bug.

Behaviour spotted while testing/working on the fix:
- You can double click a line of code and you are still offered a comment box to nowhere
- For multiple lines either individual click click click (and then click click click the same lines to unselect) or click and drag several lines and click and drag the same lines (or any combination) and you still get a comment box to nowhere

So the real fix here is probably to hide the comment box if there are no currently active lines but I don't have time right now to dig that deeply.
