### PR TITLE
Update comment.number plugin to work with latest d.o markup changes

### DIFF
--- a/src/js/plugins/comment.number.js
+++ b/src/js/plugins/comment.number.js
@@ -8,7 +8,7 @@
  */
 Drupal.behaviors.dreditorCommentNumber = {
   attach: function (context) {
-    $(context).find('#block-project-issue-issue-edit h2')
+    $(context).find('#project-issue-ajax-form h2:first')
       .append(' <strong>#' + Drupal.dreditor.issue.getNewCommentNumber() + '</strong>');
   }
 };


### PR DESCRIPTION
d.o's markup has changed. @drumm recommended to use `#project-issue-ajax-form`. I noticed that the previous selector also found a Vertical Tabs `<h2>`, which we don't want to update, hence added the `:first` pseudo-selector.
