### PR TITLE
Update form.sticky plugin to work with latest d.o markup changes

### DIFF
--- a/src/js/plugins/form.sticky.js
+++ b/src/js/plugins/form.sticky.js
@@ -11,7 +11,7 @@ Drupal.behaviors.dreditorFormSticky = {
   attach: function (context) {
     var self = this;
     // Comment body textarea form item.
-    $(context).find('form .form-item-nodechanges-comment-body-value').once('dreditor-form-sticky', function () {
+    $(context).find('#edit-nodechanges-comment .form-type-textarea').once('dreditor-form-sticky', function () {
       self.addButton($(this).find('.form-textarea-wrapper'));
     });
     // Issue summary body form item.


### PR DESCRIPTION
d.o's markup has changed. Hence the "Make sticky" button still works for the "issue summary" form (which was unaffected), but it no longer works (or even appears) for the "comment" form.
