### PR TITLE
new comments and issue pager plugins

### DIFF
--- a/src/js/plugins/issue.pager.js
+++ b/src/js/plugins/issue.pager.js
@@ -2,7 +2,7 @@
  * Duplicate the pager on top, can be handy at times.
  */
 Drupal.behaviors.issuePager = {
-	attach: function (context) {
-		$('.comments', context).prepend($('.item-list').has('.pager').clone());
-	}
+  attach: function (context) {
+    $('.comments', context).prepend($('.item-list').has('.pager').clone());
+  }
 };

--- a/src/js/plugins/issue.pager.js
+++ b/src/js/plugins/issue.pager.js
@@ -1,0 +1,8 @@
+/**
+ * Duplicate the pager on top, can be handy at times.
+ */
+Drupal.behaviors.issuePager = {
+	attach: function (context) {
+		$('.comments', context).prepend($('.item-list').has('.pager').clone());
+	}
+};

--- a/src/js/plugins/newcomments.js
+++ b/src/js/plugins/newcomments.js
@@ -1,0 +1,21 @@
+/**
+ * Helps to link the the last page with comments so that the #new works,
+ * useful for issues with more than 300 comments.
+ */
+Drupal.behaviors.newComments = {
+	threshold: 300,
+
+	attach: function (context) {
+		$('td.replies a, td.views-field-comment-count a', context).each(function() {
+			var replies = $(this).parents('td').eq(0).html().match(/[0-9]+/);
+			var newposts = $(this).html().match(/[0-9]+/);
+			if (replies && newposts) {
+				var read = replies - newposts;
+				if (read >= Drupal.behaviors.newComments.threshold) {
+					var page = parseInt(read/Drupal.behaviors.newComments.threshold, 10);
+					$(this).attr('href', $(this).attr('href').replace('#new', '?page=' + page + '#new'));
+				}
+			}
+		});
+	}
+};

--- a/src/js/plugins/newcomments.js
+++ b/src/js/plugins/newcomments.js
@@ -3,19 +3,19 @@
  * useful for issues with more than 300 comments.
  */
 Drupal.behaviors.newComments = {
-	threshold: 300,
+  threshold: 300,
 
-	attach: function (context) {
-		$('td.replies a, td.views-field-comment-count a', context).each(function() {
-			var replies = $(this).parents('td').eq(0).html().match(/[0-9]+/);
-			var newposts = $(this).html().match(/[0-9]+/);
-			if (replies && newposts) {
-				var read = replies - newposts;
-				if (read >= Drupal.behaviors.newComments.threshold) {
-					var page = parseInt(read/Drupal.behaviors.newComments.threshold, 10);
-					$(this).attr('href', $(this).attr('href').replace('#new', '?page=' + page + '#new'));
-				}
-			}
-		});
-	}
+  attach: function (context) {
+    $('td.replies a, td.views-field-comment-count a', context).each(function() {
+      var replies = $(this).parents('td').eq(0).html().match(/[0-9]+/);
+      var newposts = $(this).html().match(/[0-9]+/);
+      if (replies && newposts) {
+        var read = replies - newposts;
+        if (read >= Drupal.behaviors.newComments.threshold) {
+          var page = parseInt(read/Drupal.behaviors.newComments.threshold, 10);
+          $(this).attr('href', $(this).attr('href').replace('#new', '?page=' + page + '#new'));
+        }
+      }
+    });
+  }
 };


### PR DESCRIPTION
Keeping up with long issues (over 300 comments), like https://www.drupal.org/node/1796596 is a bit of a pain because the "xxx new" link always points to the first page, so you lose the #new anchor.

This PR uses the data in the replies column in both user post tracker and issue list and append ?page=y accordingly.

In the process of having fun contributing to dreditor, I also added another plugin to duplicate the comment pager on top. With the former plugin I don't think I will be using this more often, but I think it can be handy!
