### PR TITLE
Make use of project name when generating patch name

### DIFF
--- a/src/js/plugins/patch.name.suggestion.js
+++ b/src/js/plugins/patch.name.suggestion.js
@@ -14,7 +14,8 @@ Drupal.behaviors.dreditorPatchNameSuggestion = {
       var $link = $('<a class="dreditor-application-toggle dreditor-patchsuggestion" href="#">Patchname suggestion</a>');
       $link.prependTo($container);
       $link.click(function() {
-        var patchName = '';
+        var project = Drupal.dreditor.issue.getProjectShortName();
+        var patchName = project ? project + '-' : '';
 
         function truncateString (str, n,useWordBoundary){
           var toLong = str.length>n,


### PR DESCRIPTION
Currently Dreditor is totally ignoring the project name when generating patch name. The [official doc](https://www.drupal.org/node/707484) suggests following pattern (which includes the project name):

```
[project_name]-[short-description]-[issue-number]-[comment-number].patch
```

As you can see there is no project name in the current version: 
<img width="535" alt="screen shot 2015-08-01 at 17 51 28" src="https://cloud.githubusercontent.com/assets/1086961/9022446/f8d4102e-3875-11e5-8c0f-473f6177664d.png">

When this pull request is merged it could look like:

<img width="535" alt="screen shot 2015-08-01 at 17 55 49" src="https://cloud.githubusercontent.com/assets/1086961/9022463/9bc51490-3876-11e5-9a8a-b0640f00a7c8.png">
