### PR TITLE
Remove issue file table coloring based on legacy tests

### DIFF
--- a/src/less/dreditor.less
+++ b/src/less/dreditor.less
@@ -455,32 +455,3 @@ div.pift-operations {
   margin-left: 1em;
   text-transform: uppercase;
 }
-tr.pift-pass, tr.pift-pass td, td.pift-pass {
-  background: #DDFFDD;
-  border-color: #A6E2A6;
-  color: #008503;
-}
-tr.extended-file-field-table-row td.pift-pass {
-  border-color: #87CF87;
-}
-tr.fail, tr.pift-fail td, td.pift-fail {
-  background: #FFECEC;
-  border-color: #F5C8C8;
-  color: #CC0000;
-}
-tr.extended-file-field-table-row td.pift-fail {
-  border-color: #EEBBBB;
-}
-tr.retest, tr.pift-retest td, td.pift-retest {
-  background: #FFF4CE;
-  border-color: #F3D670;
-  color: #BB7306;
-}
-tr.extended-file-field-table-row td.pift-retest {
-  border-color: #eebf7b;
-}
-td.pift-pass, td.pift-fail, td.pift-retest {
-  a, .file .size, .pift-operations, .pift-previous {
-    color: inherit;
-  }
-}


### PR DESCRIPTION
This removes some customization based on the legacy tests, which are being deprecated. The markup for them will remain if the tests have run, but will not show in the future.

It is somewhat misleading today when both legacy and DrupalCI tests are running, CI results should be preferred.

This is a quick, untested edit via GitHub's edit UI.
