### PR TITLE
Updated manifest to include Firefox related metadata.

### DIFF
--- a/templates/chrome/manifest.json
+++ b/templates/chrome/manifest.json
@@ -20,5 +20,10 @@
     "*://*.drupal.org/*",
     "*://*.dreditor.org/*",
     "*://*.devdrupal.org/*"
-  ]
+  ],
+  "applications": {
+    "gecko": {
+      "id": "%PKG.NAME%@%PKG.NAME%.org"
+    }
+  }
 }


### PR DESCRIPTION
This change will add support for Firefox Nightly to load the WebExtension (unicorn-fail/dreditor#268).
