### PR TITLE
Help people who forget to change the status to needs review

### DIFF
--- a/src/js/plugins/patch.status.js
+++ b/src/js/plugins/patch.status.js
@@ -1,0 +1,39 @@
+/**
+ * Remind users to change status of uploaded patches.
+ */
+Drupal.behaviors.dreditorPatchStatus = {
+  attach: function (context) {
+    // Attach this behavior only to project_issue nodes. Use a fast selector for
+    // the common case, but also support comment/reply/% pages.
+    if (!($('body.node-type-project-issue', context).length || $('div.project-issue', context).length)) {
+      return;
+    }
+
+    var $context = $(context);
+    $(context).find('#project-issue-node-form').once('form-status', function () {
+      var $form = $(this);
+      var patchRegex = /\.(patch|diff)$/;
+      $form.bind('submit', function () {
+        var $files = $form.find('.ajax-new-content .file > a');
+        var hasNewPatchFiles = false;
+        $files.each(function () {
+          if (this.href.match(patchRegex)) {
+            hasNewPatchFiles = true;
+            // Return early, we found what we are looknig for.
+            return false;
+          };
+        });
+
+        // If it's not values that can trigger test bot and has files.
+        var status = $('select[name="field_issue_status[und]"]').val();
+        if (status != 8 && status != 14) {
+          var fileName = $('input.form-file', $form).val();
+          // If there are files already uploaded or about to be upload are *.patch/diff.
+          if (fileName.match(patchRegex) || hasNewPatchFiles) {
+            return window.confirm('Are you sure you want to continue without changing the status to needs review?')
+          }
+        }
+      });
+    });
+  }
+};


### PR DESCRIPTION
Here's a test to show how this works: http://jsfiddle.net/ssstgm16/2/

If a file is in the browse file field or uploaded and is a patch or diff file, this will check the status is not NR or RTBC and if so put up a JS confirm to help catch the user into setting the status before submitting.
